### PR TITLE
Optical results UX: time-series plot, filters, exports, auth welcome

### DIFF
--- a/controllers/auth_ctrl.py
+++ b/controllers/auth_ctrl.py
@@ -95,7 +95,7 @@ class AuthCtrl:
             return
 
         if self.gee_service.is_authenticated:
-            self._navigate_to_radar()
+            self._navigate_to_next()
             return
 
         project_id = self.dialog.project_id_input.text()
@@ -116,9 +116,8 @@ class AuthCtrl:
             return False
         return True
 
-    def _navigate_to_radar(self):
-        self.dialog.show_radar_page()
-        self.dialog.sar_set_tab(1)
+    def _navigate_to_next(self):
+        self.dialog.show_optical_page()
 
     def _on_browser_opened(self, url: str):
         self.dialog.set_auth_status(_tr("Waiting for sign-in in your browser…"), url)
@@ -131,7 +130,7 @@ class AuthCtrl:
 
         if success:
             self.dialog.set_auth_state("authenticated")
-            self._navigate_to_radar()
+            self._navigate_to_next()
             self.dialog.pop_message(_tr("Authentication successful!"), "info")
         elif message != CANCELLED:
             self.dialog.pop_message(message, "warning")

--- a/controllers/optical_ctrl.py
+++ b/controllers/optical_ctrl.py
@@ -17,6 +17,7 @@ from qgis.core import QgsCoordinateTransform, QgsProject
 
 from ..services.aoi_service import AOIService
 from ..tools.aoi_draw_tool import start_draw_aoi
+from ..view.optical_filter_dialog import DEFAULT_FILTER_SETTINGS
 from ..view.optical_index_info import CUSTOM_INDEX_LABEL
 from ..view.sar_plot import render_chart_html
 from ..workers.optical_worker import OpticalWorker
@@ -53,6 +54,13 @@ class OpticalCtrl:
         self._run_btn_text: str | None = None
         self._draw_tool = None
         self._plot_path: str | None = None
+        self._filter_settings = dict(DEFAULT_FILTER_SETTINGS)
+
+        # The "Adjust filter" dialog shows a live image count (cheap) and only
+        # re-renders the plot when the user clicks OK.
+        self.dialog.optical_filter_count_fn = self.count_matching
+        self.dialog.on_optical_filter_applied = self.apply_filter_settings
+        self.dialog.s2_filter_settings = dict(DEFAULT_FILTER_SETTINGS)
 
     def _release_worker(self):
         worker, self._optical_worker = self._optical_worker, None
@@ -210,10 +218,34 @@ class OpticalCtrl:
         self._render_timeseries()
         self.dialog.s2_set_tab(2)
 
+    def apply_filter_settings(self, settings: dict):
+        """Re-render the plot with new filter settings (called on dialog OK)."""
+        self._filter_settings = dict(settings)
+        if self.dataframe is not None and not self.dataframe.empty:
+            self._render_timeseries()
+
+    def count_matching(self, settings: dict) -> int:
+        """Count cached images passing the given thresholds (live, no render)."""
+        if self.dataframe is None or self.dataframe.empty:
+            return 0
+        return int(self._filter_mask(self.dataframe, settings).sum())
+
+    @staticmethod
+    def _filter_mask(df, s):
+        return (
+            (df["cloud_pct"] <= s["cloud_scene_max"])
+            & (df["valid_pixel_pct"] >= s["valid_pixel_min"])
+            & (df["coverage_pct"] >= s["coverage_min"])
+        )
+
+    def _filtered_dataframe(self) -> pd.DataFrame:
+        """Apply the current threshold filters to the cached time series."""
+        return self.dataframe[self._filter_mask(self.dataframe, self._filter_settings)]
+
     def _render_timeseries(self):
         """Plot the AOI-average time series into the optical results web view."""
         index_name = self._current_index
-        plot_df = self.dataframe.rename(columns={"date": "dates"})
+        plot_df = self._filtered_dataframe().rename(columns={"date": "dates"})
         plot_df = plot_df.dropna(subset=["dates", "AOI_average"])
 
         html = render_chart_html(

--- a/controllers/optical_ctrl.py
+++ b/controllers/optical_ctrl.py
@@ -9,17 +9,29 @@ DataFrame, including filter metadata, to the QGIS/Python console.
 
 import os
 import tempfile
+from datetime import datetime
 
 import pandas as pd
 
 from qgis.PyQt.QtCore import QCoreApplication, QUrl
-from qgis.core import QgsCoordinateTransform, QgsProject
+from qgis.PyQt.QtGui import QDesktopServices
+from qgis.PyQt.QtWidgets import QFileDialog, QProgressDialog
+from qgis.core import (
+    QgsContrastEnhancement,
+    QgsCoordinateTransform,
+    QgsMultiBandColorRenderer,
+    QgsProject,
+    QgsRasterLayer,
+)
 
+from ..managers.settings_manager import SettingsManager
 from ..services.aoi_service import AOIService
+from ..services.optical_service import OpticalService
 from ..tools.aoi_draw_tool import start_draw_aoi
 from ..view.optical_filter_dialog import DEFAULT_FILTER_SETTINGS
 from ..view.optical_index_info import CUSTOM_INDEX_LABEL
 from ..view.sar_plot import render_chart_html
+from ..workers.batch_download_worker import BatchDownloadWorker
 from ..workers.optical_worker import OpticalWorker
 
 
@@ -55,6 +67,10 @@ class OpticalCtrl:
         self._draw_tool = None
         self._plot_path: str | None = None
         self._filter_settings = dict(DEFAULT_FILTER_SETTINGS)
+        self._active_dates: list | None = None
+        self._date_filter_dialog = None
+        self._batch_worker: BatchDownloadWorker | None = None
+        self._batch_dialog: QProgressDialog | None = None
 
         # The "Adjust filter" dialog shows a live image count (cheap) and only
         # re-renders the plot when the user clicks OK.
@@ -207,21 +223,25 @@ class OpticalCtrl:
         self.dataframe = pd.DataFrame(data_rows)
         self.dataframe = self.dataframe.reindex(columns=columns)
         self._current_index = index_name
-
-        dates = self.dataframe["date"].dropna().astype(str).tolist()
-        self.dialog.s2_available_dates = dates
-        self.dialog.s2_result_date_combo.clear()
-        self.dialog.s2_result_date_combo.addItems(dates)
+        self._active_dates = None
 
         print(self.dataframe.to_string(index=False))  # TODO: remove (debug)
 
+        self._refresh_result_dates()
         self._render_timeseries()
         self.dialog.s2_set_tab(2)
 
     def apply_filter_settings(self, settings: dict):
-        """Re-render the plot with new filter settings (called on dialog OK)."""
+        """Apply new threshold filters (called on Adjust-filter OK).
+
+        Applying thresholds changes which dates qualify, so it overrides any
+        manual date selection (Filter dates) and rebuilds the single-image date
+        dropdown from the newly filtered set.
+        """
         self._filter_settings = dict(settings)
+        self._active_dates = None
         if self.dataframe is not None and not self.dataframe.empty:
+            self._refresh_result_dates()
             self._render_timeseries()
 
     def count_matching(self, settings: dict) -> int:
@@ -238,9 +258,246 @@ class OpticalCtrl:
             & (df["coverage_pct"] >= s["coverage_min"])
         )
 
+    def _threshold_dates(self) -> list:
+        """Dates passing the current thresholds (ignores manual date selection)."""
+        df = self.dataframe[self._filter_mask(self.dataframe, self._filter_settings)]
+        return df["date"].dropna().astype(str).tolist()
+
     def _filtered_dataframe(self) -> pd.DataFrame:
-        """Apply the current threshold filters to the cached time series."""
-        return self.dataframe[self._filter_mask(self.dataframe, self._filter_settings)]
+        """Cached series after thresholds and the manual date selection."""
+        df = self.dataframe[self._filter_mask(self.dataframe, self._filter_settings)]
+        if self._active_dates is not None:
+            df = df[df["date"].astype(str).isin(self._active_dates)]
+        return df
+
+    def _refresh_result_dates(self):
+        """Repopulate the single-image date dropdown from the filtered series."""
+        dates = self._filtered_dataframe()["date"].dropna().astype(str).tolist()
+        self.dialog.s2_available_dates = dates
+        combo = self.dialog.s2_result_date_combo
+        previous = combo.currentText()
+        combo.blockSignals(True)
+        combo.clear()
+        combo.addItems(dates)
+        if previous in dates:
+            combo.setCurrentText(previous)
+        combo.blockSignals(False)
+
+    # -- Filter dates (manual per-date include/exclude) -------------------
+    def handle_filter_dates(self):
+        if self.dataframe is None or self.dataframe.empty:
+            self.dialog.pop_message(_tr("Run the optical analysis first."), "warning")
+            return
+
+        if self._date_filter_dialog is not None:
+            self._date_filter_dialog.raise_()
+            self._date_filter_dialog.activateWindow()
+            return
+
+        from ..view.sar_date_filter_dialog import SARDateFilterDialog
+
+        self._date_filter_dialog = SARDateFilterDialog(
+            self._threshold_dates(), self._active_dates, parent=self.dialog
+        )
+        self._date_filter_dialog.filter_changed.connect(self._on_dates_changed)
+        self._date_filter_dialog.finished.connect(self._on_date_filter_closed)
+        self._date_filter_dialog.show()
+
+    def _on_dates_changed(self, selected_dates):
+        all_dates = self._threshold_dates()
+        self._active_dates = (
+            None if set(selected_dates) == set(all_dates) else list(selected_dates)
+        )
+        self._refresh_result_dates()
+        self._render_timeseries()
+
+    def _on_date_filter_closed(self):
+        self._date_filter_dialog = None
+
+    # -- export actions (time-series toolbar) -----------------------------
+    def _has_results(self) -> bool:
+        if self.dataframe is None or self.dataframe.empty:
+            self.dialog.pop_message(_tr("Run the optical analysis first."), "warning")
+            return False
+        return True
+
+    def _plot_dataframe(self):
+        return (
+            self._filtered_dataframe()
+            .rename(columns={"date": "dates"})
+            .dropna(subset=["dates", "AOI_average"])
+        )
+
+    def handle_open_browser(self):
+        """Open the current (filtered) time series in the system browser."""
+        if not self._has_results():
+            return
+
+        index_name = self._current_index
+        html = render_chart_html(
+            self._plot_dataframe(),
+            hide_toolbar=False,
+            title=_tr("%s Time Series") % index_name,
+            ylabel=_tr("%s AOI average") % index_name,
+        )
+        with tempfile.NamedTemporaryFile(
+            suffix=".html", delete=False, mode="w", encoding="utf-8"
+        ) as f:
+            f.write(html)
+            path = f.name
+        QDesktopServices.openUrl(QUrl.fromLocalFile(path))
+
+    def handle_export_csv(self):
+        """Export the current (filtered) time series as CSV."""
+        if not self._has_results():
+            return
+
+        date_str = datetime.now().strftime("%Y%m%d")
+        default_filename = f"optical_{self._current_index}_timeseries_{date_str}.csv"
+        file_path, _ = QFileDialog.getSaveFileName(
+            self.dialog,
+            _tr("Export Optical Time Series as CSV"),
+            default_filename,
+            _tr("CSV Files (*.csv);;All Files (*)"),
+        )
+        if not file_path:
+            return
+
+        try:
+            self._filtered_dataframe().to_csv(file_path, index=False)
+            self.dialog.pop_message(
+                _tr("CSV exported successfully to %s") % file_path, "info"
+            )
+        except Exception as e:
+            self.dialog.pop_message(_tr("Failed to export CSV: %s") % str(e), "warning")
+
+    def _buffer_meters(self) -> float:
+        slider = getattr(self.dialog, "s2_buffer_slider", None)
+        if slider is None:
+            return 0
+        value = slider.value()
+        return 0 if -3 <= value <= 3 else value  # match the UI dead-zone
+
+    def handle_batch_download(self):
+        """Download the multispectral scene of every filtered date (raw S2
+        bands, clipped to the AOI plus the buffer setting)."""
+        if not self._has_results():
+            return
+        if self._batch_worker is not None and self._batch_worker.isRunning():
+            return
+
+        dates = self._filtered_dataframe()["date"].dropna().astype(str).tolist()
+        if not dates:
+            self.dialog.pop_message(_tr("No dates selected to download."), "warning")
+            return
+
+        aoi = self.aoi
+        buffer_m = self._buffer_meters()
+        folder = SettingsManager.load_download_folder()
+
+        self._batch_dialog = QProgressDialog(
+            _tr("Preparing batch download..."),
+            _tr("Cancel"),
+            0,
+            len(dates),
+            self.dialog,
+        )
+        self._batch_dialog.setWindowTitle(_tr("Batch Download Progress"))
+        self._batch_dialog.setModal(True)
+        self._batch_dialog.show()
+
+        def _download_one(date):
+            return OpticalService.download_multispectral_for_date(
+                aoi, date, buffer_m=buffer_m, output_folder=folder
+            )
+
+        self._batch_worker = BatchDownloadWorker(dates, _download_one)
+        self._batch_worker.progress.connect(self._on_batch_progress)
+        self._batch_worker.finished.connect(self._on_batch_done)
+        self._batch_worker.cancelled.connect(self._on_batch_cancelled)
+        self._batch_worker.failed.connect(self._on_batch_failed)
+        self._batch_dialog.canceled.connect(self._batch_worker.request_cancel)
+        self._batch_worker.start()
+
+    def _on_batch_progress(self, current: int, total: int, date_str: str):
+        if self._batch_dialog is None:
+            return
+        self._batch_dialog.setMaximum(total)
+        self._batch_dialog.setValue(current)
+        self._batch_dialog.setLabelText(
+            _tr("Downloading %d of %d: %s") % (current, total, date_str)
+        )
+
+    def _on_batch_done(self, successful: int, total: int, paths: list):
+        self._close_batch_dialog()
+        self._load_downloaded_images(paths)
+        failed = total - successful
+        msg = _tr("Batch download complete: %d/%d successful") % (successful, total)
+        if failed > 0:
+            msg += _tr(" (%d failed)") % failed
+        self.dialog.pop_message(msg, "warning" if failed > 0 else "info")
+        self._batch_worker = None
+
+    def _on_batch_cancelled(self, successful: int, total: int, paths: list):
+        self._close_batch_dialog()
+        self._load_downloaded_images(paths)
+        self.dialog.pop_message(
+            _tr("Batch download cancelled. %d/%d downloaded.") % (successful, total),
+            "info",
+        )
+        self._batch_worker = None
+
+    def _on_batch_failed(self, message: str):
+        self._close_batch_dialog()
+        self.dialog.pop_message(_tr("Batch download failed: %s") % message, "warning")
+        self._batch_worker = None
+
+    def _close_batch_dialog(self):
+        if self._batch_dialog is not None:
+            self._batch_dialog.close()
+            self._batch_dialog = None
+
+    # Real-colour band positions within the _MULTISPECTRAL_BANDS stack
+    # (1-based): B4=Red, B3=Green, B2=Blue.
+    _RGB_BANDS = (4, 3, 2)
+
+    def _load_downloaded_images(self, paths: list):
+        for path in paths:
+            try:
+                name = os.path.splitext(os.path.basename(path))[0]
+                self._add_rgb_raster(path, name)
+            except Exception:
+                continue
+
+    def _add_rgb_raster(self, path: str, name: str):
+        """Load a multispectral GeoTIFF as a true-colour (B4/B3/B2) layer with a
+        2–98% cumulative-cut stretch per band, mirroring the legacy renderer."""
+        layer = QgsRasterLayer(path, name)
+        if not layer.isValid():
+            return
+
+        provider = layer.dataProvider()
+        red, green, blue = self._RGB_BANDS
+        renderer = QgsMultiBandColorRenderer(provider, red, green, blue)
+
+        extent = layer.extent()
+        for band, set_enhancement in (
+            (red, renderer.setRedContrastEnhancement),
+            (green, renderer.setGreenContrastEnhancement),
+            (blue, renderer.setBlueContrastEnhancement),
+        ):
+            val_min, val_max = provider.cumulativeCut(band, 0.02, 0.98, extent, 250000)
+            ce = QgsContrastEnhancement(provider.dataType(band))
+            ce.setContrastEnhancementAlgorithm(
+                QgsContrastEnhancement.StretchToMinimumMaximum
+            )
+            ce.setMinimumValue(val_min)
+            ce.setMaximumValue(val_max)
+            set_enhancement(ce)
+
+        layer.setRenderer(renderer)
+        QgsProject.instance().addMapLayer(layer)
+        layer.triggerRepaint()
 
     def _render_timeseries(self):
         """Plot the AOI-average time series into the optical results web view."""

--- a/controllers/optical_ctrl.py
+++ b/controllers/optical_ctrl.py
@@ -7,14 +7,18 @@ Inputs tab fetches the vegetation-index time series and prints the resulting
 DataFrame, including filter metadata, to the QGIS/Python console.
 """
 
+import os
+import tempfile
+
 import pandas as pd
 
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, QUrl
 from qgis.core import QgsCoordinateTransform, QgsProject
 
 from ..services.aoi_service import AOIService
 from ..tools.aoi_draw_tool import start_draw_aoi
 from ..view.optical_index_info import CUSTOM_INDEX_LABEL
+from ..view.sar_plot import render_chart_html
 from ..workers.optical_worker import OpticalWorker
 
 
@@ -30,13 +34,6 @@ border:3px solid #e0e0e0;border-top-color:#1b6b39;border-radius:50%;
 animation:spin .9s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}
 </style></head><body><div class="box"><div class="spinner"></div>
 <div>Fetching Sentinel-2 time series...</div></div></body></html>"""
-
-_DONE_HTML = """<!DOCTYPE html><html><head><meta charset="utf-8"><style>
-html,body{height:100%;margin:0;font-family:Arial,sans-serif;background:#fff}
-.box{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);
-text-align:center;color:#616161}.title{color:#1b6b39;font-weight:bold;margin-bottom:6px}
-</style></head><body><div class="box"><div class="title">Time series fetched</div>
-<div>DataFrame printed to the console.</div></div></body></html>"""
 
 
 class OpticalCtrl:
@@ -55,6 +52,7 @@ class OpticalCtrl:
         self._optical_worker: OpticalWorker | None = None
         self._run_btn_text: str | None = None
         self._draw_tool = None
+        self._plot_path: str | None = None
 
     def _release_worker(self):
         worker, self._optical_worker = self._optical_worker, None
@@ -107,7 +105,7 @@ class OpticalCtrl:
         canvas.refresh()
 
     def handle_optical_run(self):
-        """Fetch the optical time series and print the DataFrame to console."""
+        """Fetch the optical time series and plot it on the results page."""
 
         if self._optical_worker is not None and self._optical_worker.isRunning():
             return
@@ -207,17 +205,34 @@ class OpticalCtrl:
         self.dialog.s2_result_date_combo.clear()
         self.dialog.s2_result_date_combo.addItems(dates)
 
-        print("")
-        print(f"Optical Sentinel-2 {index_name} time-series DataFrame:")
-        print(self.dataframe.to_string(index=False))
-        print("")
+        print(self.dataframe.to_string(index=False))  # TODO: remove (debug)
 
-        self.dialog.s2_web_view.setHtml(_DONE_HTML)
+        self._render_timeseries()
         self.dialog.s2_set_tab(2)
-        self.dialog.pop_message(
-            _tr("Optical time series fetched. DataFrame printed to console."),
-            "info",
+
+    def _render_timeseries(self):
+        """Plot the AOI-average time series into the optical results web view."""
+        index_name = self._current_index
+        plot_df = self.dataframe.rename(columns={"date": "dates"})
+        plot_df = plot_df.dropna(subset=["dates", "AOI_average"])
+
+        html = render_chart_html(
+            plot_df,
+            title=_tr("%s Time Series") % index_name,
+            ylabel=_tr("%s AOI average") % index_name,
         )
+
+        fd, path = tempfile.mkstemp(suffix=".html", prefix="ravi_optical_")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(html)
+        self.dialog.s2_web_view.load(QUrl.fromLocalFile(path))
+
+        if self._plot_path and os.path.exists(self._plot_path):
+            try:
+                os.remove(self._plot_path)
+            except OSError:
+                pass
+        self._plot_path = path
 
     def _on_optical_failed(self, message):
         self._set_run_busy(False)

--- a/ravi.py
+++ b/ravi.py
@@ -210,6 +210,18 @@ class RAVI:
         self.dialog.s2_layer_combo.layerChanged.connect(
             self.optical_ctrl.handle_layer_changed
         )
+        self.dialog.s2_btn_filter_dates.clicked.connect(
+            self.optical_ctrl.handle_filter_dates
+        )
+        self.dialog.s2_btn_open_browser.clicked.connect(
+            self.optical_ctrl.handle_open_browser
+        )
+        self.dialog.s2_btn_download_csv.clicked.connect(
+            self.optical_ctrl.handle_export_csv
+        )
+        self.dialog.s2_btn_batch_download.clicked.connect(
+            self.optical_ctrl.handle_batch_download
+        )
 
         self.dialog.sar_btn_hybrid_layer.clicked.connect(
             self.dem_ctrl.handle_hybrid_layer

--- a/services/optical_service.py
+++ b/services/optical_service.py
@@ -87,7 +87,10 @@ class OpticalService:
                 }
             )
 
-        return collection.map(tag).sort("dedup_score", False).distinct("date")
+        # distinct() returns a generic Collection; re-cast to ImageCollection so
+        # downstream map() yields ee.Image elements (not ee.Feature).
+        deduped = collection.map(tag).sort("dedup_score", False).distinct("date")
+        return ee.ImageCollection(deduped)
 
     @staticmethod
     def _build_valid_scl_mask(

--- a/services/optical_service.py
+++ b/services/optical_service.py
@@ -1,8 +1,25 @@
-import ee
-
+import os
+import tempfile
+from datetime import datetime, timedelta
 from typing import List, Dict, Any
 
+import ee
+import requests
+
+try:
+    from osgeo import gdal
+except ImportError:
+    gdal = None
+
 from ..tools.indexes import INDEX_REGISTRY, calc_custom
+
+
+# Raw Sentinel-2 SR multispectral bands written by the batch download (no
+# computed index bands). B10 is absent from the surface-reflectance product.
+_MULTISPECTRAL_BANDS = [
+    "B1", "B2", "B3", "B4", "B5", "B6",
+    "B7", "B8", "B8A", "B9", "B11", "B12",
+]
 
 
 class OpticalService:
@@ -215,3 +232,99 @@ class OpticalService:
                 rows.append(property)
 
         return rows
+
+    # -- multispectral export (batch download) ----------------------------
+    @staticmethod
+    def _download_region(aoi: ee.FeatureCollection, buffer_m: float):
+        """AOI geometry, optionally buffered (positive grows, negative crops)."""
+        geometry = aoi.geometry()
+        if buffer_m:
+            geometry = geometry.buffer(buffer_m)
+        return geometry
+
+    @staticmethod
+    def get_multispectral_image_for_date(
+        aoi: ee.FeatureCollection, date: str, buffer_m: float = 0
+    ):
+        """Single Sentinel-2 SR multispectral image for ``date`` (one scene per
+        date, same pick as the time series), clipped to the buffered AOI."""
+        region = OpticalService._download_region(aoi, buffer_m)
+        next_date = (
+            datetime.strptime(date, "%Y-%m-%d") + timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+
+        collection = (
+            ee.ImageCollection("COPERNICUS/S2_SR_HARMONIZED")
+            .filterBounds(aoi)
+            .filterDate(date, next_date)
+        )
+        collection = OpticalService._keep_one_image_per_date(collection, aoi)
+        image = ee.Image(collection.first()).select(_MULTISPECTRAL_BANDS)
+        return image.clip(region), region
+
+    @staticmethod
+    def download_multispectral_for_date(
+        aoi: ee.FeatureCollection,
+        date: str,
+        buffer_m: float = 0,
+        output_folder: str = None,
+    ) -> str:
+        """Download the multispectral scene for ``date`` as a GeoTIFF and return
+        its path. Raises on a failed HTTP download."""
+        image, region = OpticalService.get_multispectral_image_for_date(
+            aoi, date, buffer_m
+        )
+        url = image.getDownloadURL(
+            {
+                "scale": 10,
+                "region": region.bounds().getInfo(),
+                "format": "GeoTIFF",
+                "crs": "EPSG:4326",
+            }
+        )
+
+        response = requests.get(url, timeout=300)
+        if not response.ok:
+            raise RuntimeError(
+                f"Optical download failed (HTTP {response.status_code}): "
+                f"{response.reason}"
+            )
+
+        base_dir = (
+            output_folder
+            if (output_folder and os.path.isdir(output_folder))
+            else tempfile.gettempdir()
+        )
+        output_path = OpticalService._unique_path(base_dir, f"Sentinel2_{date}.tiff")
+        with open(output_path, "wb") as f:
+            f.write(response.content)
+
+        OpticalService._set_band_names(output_path)
+        return output_path
+
+    @staticmethod
+    def _unique_path(folder: str, filename: str) -> str:
+        path = os.path.join(folder, filename)
+        if not os.path.exists(path):
+            return path
+        stem, ext = os.path.splitext(filename)
+        i = 1
+        while os.path.exists(os.path.join(folder, f"{stem}_{i}{ext}")):
+            i += 1
+        return os.path.join(folder, f"{stem}_{i}{ext}")
+
+    @staticmethod
+    def _set_band_names(file_path: str):
+        if gdal is None:
+            return
+        try:
+            dataset = gdal.Open(file_path, gdal.GA_Update)
+            if dataset is None:
+                return
+            for i in range(1, min(dataset.RasterCount + 1, len(_MULTISPECTRAL_BANDS) + 1)):
+                band = dataset.GetRasterBand(i)
+                if band is not None:
+                    band.SetDescription(_MULTISPECTRAL_BANDS[i - 1])
+            dataset = None
+        except Exception:
+            pass

--- a/services/optical_service.py
+++ b/services/optical_service.py
@@ -89,30 +89,25 @@ class OpticalService:
 
         geometry = aoi.geometry()
 
-        # Total pixels in the AOI (unmask -> every pixel counts, including
-        # NODATA), used as the denominator for both coverage and valid-pixel %.
+        # Geometry-based coverage (legacy): cheaper than a pixel count, but uses
+        # image.geometry(), which for Sentinel-2 is the full nominal MGRS tile
+        # square. AOIs inside a single tile therefore read ~100% even when the
+        # swath only partially covers them; it only catches AOIs that extend
+        # past a granule footprint (e.g. spanning multiple tiles).
+        intersection_area = (
+            image.geometry().intersection(geometry, ee.ErrorMargin(1)).area()
+        )
+        aoi_area = geometry.area()
+        coverage_percentage = (
+            ee.Number(intersection_area).divide(aoi_area).multiply(100)
+        )
+
         total_pixels = (
             scl_band.unmask()
             .reduceRegion(
                 reducer=ee.Reducer.count(), geometry=geometry, scale=10, maxPixels=1e9
             )
             .getNumber("SCL")
-        )
-
-        # Actual data pixels in the AOI. The SCL band is masked where the
-        # granule has no data, so counting it WITHOUT unmask gives the real
-        # footprint. We avoid image.geometry() here: for Sentinel-2 it returns
-        # the full nominal MGRS tile square, so swath-edge granules with NODATA
-        # still report 100% coverage.
-        data_pixels = (
-            scl_band.reduceRegion(
-                reducer=ee.Reducer.count(), geometry=geometry, scale=10, maxPixels=1e9
-            ).getNumber("SCL")
-        )
-        coverage_percentage = ee.Algorithms.If(
-            ee.Number(total_pixels).gt(0),
-            ee.Number(data_pixels).divide(total_pixels).multiply(100),
-            0,
         )
 
         valid_mask = OpticalService._build_valid_scl_mask(

--- a/services/optical_service.py
+++ b/services/optical_service.py
@@ -89,20 +89,30 @@ class OpticalService:
 
         geometry = aoi.geometry()
 
-        intersection_area = (
-            image.geometry().intersection(geometry, ee.ErrorMargin(1)).area()
-        )
-        aoi_area = geometry.area()
-        coverage_percentage = (
-            ee.Number(intersection_area).divide(aoi_area).multiply(100)
-        )
-
+        # Total pixels in the AOI (unmask -> every pixel counts, including
+        # NODATA), used as the denominator for both coverage and valid-pixel %.
         total_pixels = (
             scl_band.unmask()
             .reduceRegion(
                 reducer=ee.Reducer.count(), geometry=geometry, scale=10, maxPixels=1e9
             )
             .getNumber("SCL")
+        )
+
+        # Actual data pixels in the AOI. The SCL band is masked where the
+        # granule has no data, so counting it WITHOUT unmask gives the real
+        # footprint. We avoid image.geometry() here: for Sentinel-2 it returns
+        # the full nominal MGRS tile square, so swath-edge granules with NODATA
+        # still report 100% coverage.
+        data_pixels = (
+            scl_band.reduceRegion(
+                reducer=ee.Reducer.count(), geometry=geometry, scale=10, maxPixels=1e9
+            ).getNumber("SCL")
+        )
+        coverage_percentage = ee.Algorithms.If(
+            ee.Number(total_pixels).gt(0),
+            ee.Number(data_pixels).divide(total_pixels).multiply(100),
+            0,
         )
 
         valid_mask = OpticalService._build_valid_scl_mask(

--- a/services/optical_service.py
+++ b/services/optical_service.py
@@ -22,6 +22,7 @@ class OpticalService:
     ) -> List[Dict[str, Any]]:
 
         collection = OpticalService._build_base_collection(aoi, date_start, date_end)
+        collection = OpticalService._keep_one_image_per_date(collection, aoi)
 
         def process_image(image):
             processed_image = OpticalService._add_vegetation_index(image, index_name)
@@ -48,6 +49,45 @@ class OpticalService:
             .filterBounds(aoi)
             .filterDate(date_start, date_end)
         )
+
+    @staticmethod
+    def _keep_one_image_per_date(
+        collection: ee.ImageCollection, aoi: ee.FeatureCollection
+    ) -> ee.ImageCollection:
+        """Keep a single image per acquisition date (always on).
+
+        Criteria: highest AOI footprint coverage first, cloud cover as the
+        tiebreaker. Both come from cheap geometry/metadata (no reduceRegion), so
+        the expensive per-image statistics are computed for the kept images
+        alone -- unlike the legacy approach, which derived stats before
+        deduplicating. Footprint coverage uses image.geometry() (the full MGRS
+        tile for Sentinel-2), so single-tile AOIs tie at full coverage and the
+        cloud tiebreaker decides.
+        """
+        geometry = aoi.geometry()
+        aoi_area = geometry.area()
+
+        def tag(image):
+            coverage = (
+                image.geometry()
+                .intersection(geometry, ee.ErrorMargin(1))
+                .area()
+                .divide(aoi_area)
+            )
+            cloud = ee.Number(image.get("CLOUDY_PIXEL_PERCENTAGE"))
+            # Composite descending score: coverage dominates, low cloud breaks
+            # ties (coverage in [0,1] scaled by 1000 outweighs cloud in [0,100]).
+            score = coverage.multiply(1000).subtract(cloud.divide(100))
+            return image.set(
+                {
+                    "date": ee.Date(image.get("system:time_start")).format(
+                        "YYYY-MM-dd"
+                    ),
+                    "dedup_score": score,
+                }
+            )
+
+        return collection.map(tag).sort("dedup_score", False).distinct("date")
 
     @staticmethod
     def _build_valid_scl_mask(

--- a/ui/intro.html
+++ b/ui/intro.html
@@ -64,8 +64,8 @@
     <div class="section">
         <p>
             <strong>RAVI</strong> originated as the undergraduate final project (TCC) of
-            <strong><a href="https://shorturl.at/EJm3k" target="_blank">Caio Arantes</a></strong>, developed under the supervision of
-            <strong><a href="https://shorturl.at/tA35F" target="_blank">Prof. Dr. Lucas dos Rios Amaral</a></strong>. Currently, RAVI is an
+            <strong><a href="https://www.linkedin.com/in/caioarantes/" target="_blank">Caio Arantes</a></strong>, developed under the supervision of
+            <strong><a href="https://www.linkedin.com/in/lucas-rios-do-amaral-bb302449/" target="_blank">Prof. Dr. Lucas dos Rios Amaral</a></strong>. Currently, RAVI is an
             <strong>open-source project</strong> maintained with the support of
             <strong>FARM Analytica</strong>, a company co-founded by Caio Arantes.
             The project remains committed to <strong>technology diffusion</strong> and

--- a/ui/intro_pt.html
+++ b/ui/intro_pt.html
@@ -64,8 +64,8 @@
     <div class="section">
         <p>
             O <strong>RAVI</strong> teve início como trabalho de conclusão de curso (TCC) de
-            <strong><a href="https://shorturl.at/EJm3k" target="_blank">Caio Arantes</a></strong>, desenvolvido sob orientação do
-            <strong><a href="https://shorturl.at/tA35F" target="_blank">Prof. Dr. Lucas dos Rios Amaral</a></strong>. Atualmente, o RAVI é um
+            <strong><a href="https://www.linkedin.com/in/caioarantes/" target="_blank">Caio Arantes</a></strong>, desenvolvido sob orientação do
+            <strong><a href="https://www.linkedin.com/in/lucas-rios-do-amaral-bb302449/" target="_blank">Prof. Dr. Lucas dos Rios Amaral</a></strong>. Atualmente, o RAVI é um
             <strong>projeto de código aberto</strong>, mantido com o apoio da
             <strong>FARM Analytica</strong>, empresa cofundada por Caio Arantes. O projeto
             mantém seu compromisso com a <strong>difusão tecnológica</strong> e com o

--- a/view/auth.py
+++ b/view/auth.py
@@ -16,6 +16,7 @@ from qgis.PyQt.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QScrollArea,
     QVBoxLayout,
     QWidget,
 )
@@ -26,6 +27,127 @@ from .styles import STYLE_BTN_PRIMARY, STYLE_BTN_SECONDARY
 
 def _tr(text):
     return QCoreApplication.translate("RAVI", text)
+
+
+# External links (mirrors ui/intro.html).
+_URL_CAIO = "https://www.linkedin.com/in/caioarantes/"
+_URL_LUCAS = "https://www.linkedin.com/in/lucas-rios-do-amaral-bb302449/"
+_URL_FARM = "https://farmanalytica.com.br"
+_URL_SITE = "https://www.raviqgis.org"
+_LINK_STYLE = "color:#1b6b39; font-weight:bold; text-decoration:none;"
+
+# Feature overview shown on the Auth page. Each entry is (name, one-line what).
+# Keep names aligned with the per-page intros (optical.py, sysi.py, radar.py).
+_FEATURES = [
+    ("Optical time series",
+     "Per-date Sentinel-2 vegetation-index series (NDVI, EVI, NDRE, NDWI, NBR…) "
+     "over your AOI, with SCL cloud/shadow masking and date filtering"),
+    ("Custom indices",
+     "Build your own index from band math and reuse it across the whole series"),
+    ("Synthetic composite",
+     "Reduce a series to one image (mean, median, max, AUC…) for a clean snapshot"),
+    ("Multispectral RGB",
+     "True- and false-colour composites for any acquisition date, styled in QGIS"),
+    ("SYSI — synthetic soil image",
+     "Bare-soil reflectance composite (GEOS3) from cloud-free pixels for soil mapping"),
+    ("Radar (SAR)",
+     "Sentinel-1 VV/VH backscatter time series — cloud-independent monitoring"),
+    ("DEM download",
+     "Fetch terrain elevation models (SRTM, Copernicus…) clipped to your area"),
+    ("Climate overlay",
+     "Overlay daily NASA POWER precipitation and min/max temperature on the plot"),
+    ("Point &amp; feature analysis",
+     "Per-feature or per-point series with adjustable buffer and value extraction"),
+    ("Batch download &amp; CSV",
+     "Export every selected date as rasters and the full data table as CSV"),
+]
+
+
+def _build_intro_section():
+    """Full-width banner: condensed RAVI story + an overview of every feature.
+
+    The narrative is distilled from ui/intro.html; the feature grid mirrors the
+    per-module intro tabs so the Auth page doubles as a landing overview.
+    """
+    frame = QFrame()
+    frame.setMinimumWidth(280)
+    frame.setStyleSheet("""
+        QFrame {
+            background-color: #ffffff;
+            border: 1px solid #e0e0e0;
+            border-radius: 12px;
+        }
+        QLabel { background: transparent; border: none; }
+    """)
+    lay = QVBoxLayout(frame)
+    lay.setContentsMargins(18, 14, 18, 14)
+    lay.setSpacing(10)
+
+    title = QLabel(_tr("Welcome to RAVI"))
+    title.setStyleSheet("color: #1a1a1a; font-size: 18px; font-weight: bold;")
+    lay.addWidget(title)
+
+    story = QLabel(
+        _tr(
+            "<b>RAVI</b> (Remote Analysis of Vegetation Indices) began as the "
+            "undergraduate thesis of "
+            "<a href='{caio}' style='{ls}'>Caio Arantes</a>, supervised by "
+            "<a href='{lucas}' style='{ls}'>Prof. Dr. Lucas dos Rios Amaral</a>, "
+            "and is now an open-source project maintained with the support of "
+            "<a href='{farm}' style='{ls}'>FARM Analytica</a>, co-founded by Caio. "
+            "Committed to technology diffusion and the open-source philosophy, it "
+            "brings <b>Google Earth Engine</b> processing into QGIS — turning "
+            "satellite archives into vegetation, soil, radar and climate insight, "
+            "without leaving your map."
+        ).format(caio=_URL_CAIO, lucas=_URL_LUCAS, farm=_URL_FARM, ls=_LINK_STYLE)
+    )
+    story.setWordWrap(True)
+    story.setTextFormat(Qt.TextFormat.RichText)
+    story.setOpenExternalLinks(True)
+    story.setStyleSheet("color: #555555; font-size: 12px; line-height: 1.4;")
+    lay.addWidget(story)
+
+    feat_caption = QLabel(_tr("WHAT YOU CAN DO"))
+    feat_caption.setStyleSheet(
+        "color: #1b6b39; font-size: 11px; letter-spacing: 1px; font-weight: bold;"
+    )
+    lay.addWidget(feat_caption)
+
+    # Split the features into two balanced columns of rich-text bullets.
+    half = (len(_FEATURES) + 1) // 2
+    columns = QHBoxLayout()
+    columns.setContentsMargins(0, 0, 0, 0)
+    columns.setSpacing(20)
+    for chunk in (_FEATURES[:half], _FEATURES[half:]):
+        items = "".join(
+            f"<p style='margin:0 0 8px 0;'>"
+            f"<b style='color:#1b6b39;'>{name}</b><br>"
+            f"<span style='color:#616161;'>{desc}</span></p>"
+            for name, desc in chunk
+        )
+        col = QLabel(items)
+        col.setWordWrap(True)
+        col.setTextFormat(Qt.TextFormat.RichText)
+        col.setAlignment(Qt.AlignmentFlag.AlignTop)
+        col.setStyleSheet("font-size: 12px;")
+        columns.addWidget(col, 1)
+    lay.addLayout(columns)
+
+    footer = QLabel(
+        _tr(
+            "Learn more and read the setup guide at "
+            "<a href='{site}' style='{ls}'>www.raviqgis.org</a> · "
+            "Commercial inquiries: "
+            "<a href='{farm}' style='{ls}'>FARM Analytica</a>"
+        ).format(site=_URL_SITE, farm=_URL_FARM, ls=_LINK_STYLE)
+    )
+    footer.setWordWrap(True)
+    footer.setTextFormat(Qt.TextFormat.RichText)
+    footer.setOpenExternalLinks(True)
+    footer.setStyleSheet("color: #9e9e9e; font-size: 11px; padding-top: 4px;")
+    lay.addWidget(footer)
+
+    return frame
 
 
 def setup_auth_page(dialog, page):
@@ -44,80 +166,49 @@ def setup_auth_page(dialog, page):
     """
     page.setStyleSheet("background-color: #f5f5f5;")
 
-    outer = QVBoxLayout(page)
-    outer.setContentsMargins(0, 0, 0, 0)
-    outer.setSpacing(0)
-    outer.addStretch(2)
+    # Two columns that scroll independently: welcome (left) and auth (right).
+    page_lay = QHBoxLayout(page)
+    page_lay.setContentsMargins(16, 16, 16, 16)
+    page_lay.setSpacing(20)
 
-    row = QHBoxLayout()
-    row.setContentsMargins(28, 0, 28, 0)
-    row.setSpacing(34)
+    def _make_scroll():
+        sc = QScrollArea()
+        sc.setWidgetResizable(True)
+        sc.setFrameShape(QFrame.Shape.NoFrame)
+        sc.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        sc.setStyleSheet("QScrollArea { background: transparent; border: none; }")
+        return sc
 
-    left = QWidget()
-    left.setFixedWidth(230)
-    left.setStyleSheet("background: transparent;")
-    left_lay = QVBoxLayout(left)
-    left_lay.setContentsMargins(0, 0, 0, 0)
-    left_lay.setSpacing(8)
+    # LEFT column: welcome story + feature overview.
+    left_scroll = _make_scroll()
+    left_scroll.setWidget(_build_intro_section())
+    page_lay.addWidget(left_scroll, 1)
 
-    left_lay.addStretch(1)
+    # RIGHT column: sign-in card (page focus), status, GEE prerequisites.
+    right_scroll = _make_scroll()
+    page_lay.addWidget(right_scroll, 1)
 
-    title_lbl = QLabel(_tr("GEE Authentication"))
-    title_lbl.setStyleSheet("color: #1a1a1a; font-size: 18px; font-weight: bold;")
-    left_lay.addWidget(title_lbl)
+    right = QWidget()
+    right.setStyleSheet("background: transparent;")
+    right_scroll.setWidget(right)
+    right_lay = QVBoxLayout(right)
+    right_lay.setContentsMargins(0, 0, 0, 0)
+    right_lay.setSpacing(12)
 
-    desc_lbl = QLabel(
-        _tr(
-            "RAVI uses <b>Google Earth Engine</b> for processing. "
-            "To continue, you will need authorized access."
-        )
+    auth_heading = QLabel(_tr("GEE Authentication"))
+    auth_heading.setStyleSheet(
+        "color: #1a1a1a; font-size: 16px; font-weight: bold;"
     )
-    desc_lbl.setWordWrap(True)
-    desc_lbl.setTextFormat(Qt.TextFormat.RichText)
-    desc_lbl.setStyleSheet("color: #616161; font-size: 13px;")
-    left_lay.addWidget(desc_lbl)
-
-    info_frame = QFrame()
-    info_frame.setStyleSheet("""
-        QFrame {
-            background-color: #e8f5e9;
-            border-left: 3px solid #43a047;
-            border-radius: 4px;
-        }
-        QLabel { background: transparent; border: none; }
-    """)
-    info_lay = QHBoxLayout(info_frame)
-    info_lay.setContentsMargins(12, 10, 12, 10)
-    info_lay.setSpacing(8)
-
-    info_icon = QLabel("ⓘ")
-    info_icon.setFixedWidth(18)
-    info_icon.setAlignment(Qt.AlignmentFlag.AlignTop)
-    info_icon.setStyleSheet("color: #2e7d32; font-size: 14px; font-weight: bold;")
-    info_lay.addWidget(info_icon)
-
-    info_text = QLabel(
-        _tr(
-            "Requires an active GEE account and a Google Cloud Console project "
-            "with the API enabled."
-        )
-    )
-    info_text.setWordWrap(True)
-    info_text.setStyleSheet("color: #1b5e20; font-size: 12px;")
-    info_lay.addWidget(info_text, 1)
-
-    left_lay.addWidget(info_frame)
-    left_lay.addStretch(1)
-    row.addStretch(1)
-    row.addWidget(left)
+    right_lay.addWidget(auth_heading)
 
     card = QFrame()
-    card.setFixedWidth(258)
     card.setFixedHeight(250)
+    # Accent border keeps the sign-in card the visual focus of the page, even
+    # below the feature banner.
     card.setStyleSheet("""
         QFrame {
             background-color: #ffffff;
-            border: 1px solid #e0e0e0;
+            border: 2px solid #1b6b39;
             border-radius: 12px;
         }
         QLabel { background: transparent; border: none; }
@@ -198,11 +289,8 @@ def setup_auth_page(dialog, page):
     card_lay.addWidget(dialog.btn_reset_auth, 0, Qt.AlignmentFlag.AlignHCenter)
     card_lay.addStretch(1)
 
-    row.addWidget(card)
-    row.addStretch(1)
-    outer.addLayout(row)
+    right_lay.addWidget(card)
 
-    outer.addSpacing(6)
     dialog.auth_status_lbl = QLabel("")
     dialog.auth_status_lbl.setWordWrap(True)
     dialog.auth_status_lbl.setTextFormat(Qt.TextFormat.RichText)
@@ -210,16 +298,44 @@ def setup_auth_page(dialog, page):
     dialog.auth_status_lbl.setAlignment(Qt.AlignmentFlag.AlignHCenter)
     dialog.auth_status_lbl.setStyleSheet("color: #616161; font-size: 11px;")
     dialog.auth_status_lbl.hide()
-    outer.addWidget(dialog.auth_status_lbl)
+    right_lay.addWidget(dialog.auth_status_lbl)
+
+    info_frame = QFrame()
+    info_frame.setStyleSheet("""
+        QFrame {
+            background-color: #e8f5e9;
+            border-left: 3px solid #43a047;
+            border-radius: 4px;
+        }
+        QLabel { background: transparent; border: none; }
+    """)
+    info_lay = QHBoxLayout(info_frame)
+    info_lay.setContentsMargins(12, 10, 12, 10)
+    info_lay.setSpacing(8)
+
+    info_icon = QLabel("ⓘ")
+    info_icon.setFixedWidth(18)
+    info_icon.setAlignment(Qt.AlignmentFlag.AlignTop)
+    info_icon.setStyleSheet("color: #2e7d32; font-size: 14px; font-weight: bold;")
+    info_lay.addWidget(info_icon)
+
+    info_text = QLabel(
+        _tr(
+            "Requires an active GEE account and a Google Cloud Console project "
+            "with the API enabled."
+        )
+    )
+    info_text.setWordWrap(True)
+    info_text.setStyleSheet("color: #1b5e20; font-size: 12px;")
+    info_lay.addWidget(info_text, 1)
+
+    right_lay.addWidget(info_frame)
 
     dialog.btn_go_to_aoi = QPushButton(page)
     dialog.btn_go_to_aoi.hide()
     dialog.btn_go_to_aoi.clicked.connect(dialog.show_dem_page)
 
-    outer.addStretch(2)
-
     folder_frame = QFrame()
-    folder_frame.setFixedWidth(560)
     folder_frame.setStyleSheet("""
         QFrame {
             background-color: #ffffff;
@@ -228,13 +344,17 @@ def setup_auth_page(dialog, page):
         }
         QLabel { background: transparent; border: none; }
     """)
-    folder_lay = QHBoxLayout(folder_frame)
-    folder_lay.setContentsMargins(14, 8, 10, 8)
+    folder_lay = QVBoxLayout(folder_frame)
+    folder_lay.setContentsMargins(14, 10, 14, 10)
     folder_lay.setSpacing(8)
 
     folder_lbl = QLabel(_tr("Download folder"))
     folder_lbl.setStyleSheet("color: #616161; font-size: 11px; font-weight: bold;")
     folder_lay.addWidget(folder_lbl)
+
+    folder_input_row = QHBoxLayout()
+    folder_input_row.setContentsMargins(0, 0, 0, 0)
+    folder_input_row.setSpacing(8)
 
     dialog.folder_input = QLineEdit()
     dialog.folder_input.setReadOnly(True)
@@ -250,7 +370,7 @@ def setup_auth_page(dialog, page):
             font-size: 12px;
         }
     """)
-    folder_lay.addWidget(dialog.folder_input, 1)
+    folder_input_row.addWidget(dialog.folder_input, 1)
 
     dialog.btn_clear_folder = QPushButton("✕")
     dialog.btn_clear_folder.setFixedSize(28, 28)
@@ -269,12 +389,14 @@ def setup_auth_page(dialog, page):
         }
         QPushButton:disabled { color: #eeeeee; }
     """)
-    folder_lay.addWidget(dialog.btn_clear_folder)
+    folder_input_row.addWidget(dialog.btn_clear_folder)
 
     dialog.btn_browse_folder = QPushButton(_tr("Browse"))
     dialog.btn_browse_folder.setFixedHeight(28)
     dialog.btn_browse_folder.setStyleSheet(STYLE_BTN_SECONDARY)
-    folder_lay.addWidget(dialog.btn_browse_folder)
+    folder_input_row.addWidget(dialog.btn_browse_folder)
+
+    folder_lay.addLayout(folder_input_row)
 
     def _sync_clear_enabled(text):
         dialog.btn_clear_folder.setEnabled(bool(text))
@@ -282,11 +404,5 @@ def setup_auth_page(dialog, page):
     dialog.folder_input.textChanged.connect(_sync_clear_enabled)
     _sync_clear_enabled(dialog.folder_input.text())
 
-    folder_outer_row = QHBoxLayout()
-    folder_outer_row.setContentsMargins(0, 0, 0, 0)
-    folder_outer_row.addStretch(1)
-    folder_outer_row.addWidget(folder_frame)
-    folder_outer_row.addStretch(1)
-    outer.addLayout(folder_outer_row)
-
-    outer.addSpacing(16)
+    right_lay.addWidget(folder_frame)
+    right_lay.addStretch(1)

--- a/view/optical.py
+++ b/view/optical.py
@@ -831,21 +831,25 @@ def _wire_filter_dialog(dialog):
     """Attach the lazy openers for the client-side filter popup and the per-date
     selection dialog.
 
-    Front-end only: each opener caches the chosen settings/dates on ``dialog``.
-    Re-rendering the plot from them is a later backend task.
+    The filter popup shows a live image count while the sliders move
+    (``optical_filter_count_fn``), but only applies to the plot on OK, via
+    ``on_optical_filter_applied`` (both set by the controller).
     """
     dialog.s2_filter_settings = None
     dialog.s2_active_dates = None
 
     def _open_filter():
-        popup = OpticalFilterDialog(settings=dialog.s2_filter_settings, parent=dialog)
-
-        def _capture(settings):
-            dialog.s2_filter_settings = settings
-
-        popup.filter_changed.connect(_capture)
+        popup = OpticalFilterDialog(
+            settings=dialog.s2_filter_settings,
+            count_fn=getattr(dialog, "optical_filter_count_fn", None),
+            parent=dialog,
+        )
         if popup.exec():
-            dialog.s2_filter_settings = popup.get_settings()
+            settings = popup.get_settings()
+            dialog.s2_filter_settings = settings
+            hook = getattr(dialog, "on_optical_filter_applied", None)
+            if hook is not None:
+                hook(settings)
 
     def _open_dates():
         dates = getattr(dialog, "s2_available_dates", None) or []

--- a/view/optical.py
+++ b/view/optical.py
@@ -53,7 +53,6 @@ from .radar import (
 )
 from .styles import STYLE_BTN_PRIMARY, STYLE_BTN_SECONDARY, STYLE_CHECKBOX
 from .optical_filter_dialog import OpticalFilterDialog
-from .sar_date_filter_dialog import SARDateFilterDialog
 from .optical_index_info import (
     CUSTOM_BAND_REFERENCE,
     CUSTOM_INDEX_LABEL,
@@ -851,18 +850,10 @@ def _wire_filter_dialog(dialog):
             if hook is not None:
                 hook(settings)
 
-    def _open_dates():
-        dates = getattr(dialog, "s2_available_dates", None) or []
-        popup = SARDateFilterDialog(dates, dialog.s2_active_dates, parent=dialog)
-        popup.filter_changed.connect(
-            lambda selected: setattr(dialog, "s2_active_dates", list(selected))
-        )
-        popup.exec()
-
+    # The "Filter dates" button is wired to OpticalCtrl.handle_filter_dates in
+    # ravi.py (it owns the active-date state and re-renders the plot).
     dialog.open_optical_filter_dialog = _open_filter
-    dialog.open_optical_date_filter = _open_dates
     dialog.s2_btn_adjust_filter.clicked.connect(_open_filter)
-    dialog.s2_btn_filter_dates.clicked.connect(_open_dates)
 
 def setup_optical_page(dialog, page):
     """

--- a/view/optical.py
+++ b/view/optical.py
@@ -552,16 +552,9 @@ def _build_results_tab(dialog, parent):
     # --- Single-date image (shared date; RGB or VI output) --------------
     single_panel = _section_panel()
     single_lay = QVBoxLayout(single_panel)
-    single_lay.setContentsMargins(16, 14, 16, 14)
-    single_lay.setSpacing(10)
+    single_lay.setContentsMargins(16, 12, 16, 12)
+    single_lay.setSpacing(6)
     single_lay.addWidget(_caption(_tr("SINGLE-DATE IMAGE")))
-    single_hint = QLabel(_tr(
-        "Download the image for one date as a multispectral RGB composite or as "
-        "a single-band vegetation index."
-    ))
-    single_hint.setWordWrap(True)
-    single_hint.setStyleSheet("color: #616161; font-size: 11px; background: transparent; border: none;")
-    single_lay.addWidget(single_hint)
 
     dialog.s2_result_date_combo = QComboBox()
     _prepare_field(dialog.s2_result_date_combo, 30)
@@ -569,38 +562,52 @@ def _build_results_tab(dialog, parent):
     dialog.s2_result_date_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
     dialog.s2_result_date_combo.view().setStyleSheet(_POPUP_VIEW_STYLE)
 
-    dialog.s2_output_type_combo = QComboBox()
-    _prepare_field(dialog.s2_output_type_combo, 30)
-    dialog.s2_output_type_combo.addItem(_tr("Multispectral (RGB)"), "rgb")
-    dialog.s2_output_type_combo.addItem(_tr("Vegetation Index"), "index")
-    dialog.s2_output_type_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
-    dialog.s2_output_type_combo.view().setStyleSheet(_POPUP_VIEW_STYLE)
+    def _subrow(title, widgets):
+        """A light inner card: an inline caption followed by the controls and
+        per-output download buttons, all on one wrapping row."""
+        frame = QFrame()
+        frame.setStyleSheet(
+            "QFrame { background: #fbfcfb; border: 1px solid #e8eee9;"
+            " border-radius: 6px; }"
+            "QLabel { background: transparent; border: none; }"
+        )
+        box = QVBoxLayout(frame)
+        box.setContentsMargins(10, 6, 10, 6)
+        box.setSpacing(0)
+        cap = QLabel(title)
+        cap.setStyleSheet(
+            "color: #1b6b39; font-size: 10px; font-weight: bold; letter-spacing: 1px;"
+        )
+        box.addWidget(_flow([cap, *widgets], spacing=10))
+        return frame
 
-    # RGB controls — just the composite rendering.
-    rgb_page = QWidget()
-    rgb_page.setStyleSheet("background: transparent;")
-    rgb_page_lay = QHBoxLayout(rgb_page)
-    rgb_page_lay.setContentsMargins(0, 0, 0, 0)
-    rgb_page_lay.setSpacing(12)
+    # Shared date selector for both single-date outputs.
+    single_lay.addWidget(_labeled(_tr("Date"), dialog.s2_result_date_combo, 34))
+
+    # --- Multispectral (RGB) ---
     dialog.s2_rgb_render_combo = QComboBox()
     _prepare_field(dialog.s2_rgb_render_combo, 30)
-    dialog.s2_rgb_render_combo.setMinimumWidth(220)
+    dialog.s2_rgb_render_combo.setMinimumWidth(200)
     dialog.s2_rgb_render_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
     for _label, _key in _RGB_RENDER_MODES:
         dialog.s2_rgb_render_combo.addItem(_label, _key)
     dialog.s2_rgb_render_combo.view().setStyleSheet(_POPUP_VIEW_STYLE)
-    rgb_page_lay.addWidget(_labeled(_tr("Rendering"), dialog.s2_rgb_render_combo, 70))
-    rgb_page_lay.addStretch(1)
+    dialog.s2_btn_rgb_preview = QPushButton(_tr("Preview"))
+    dialog.s2_btn_rgb_preview.setFixedHeight(30)
+    dialog.s2_btn_rgb_preview.setStyleSheet(STYLE_BTN_PRIMARY)
+    dialog.s2_btn_rgb_download = QPushButton(_tr("Download & Preview").replace("&", "&&"))
+    dialog.s2_btn_rgb_download.setFixedHeight(30)
+    dialog.s2_btn_rgb_download.setStyleSheet(STYLE_BTN_SECONDARY)
+    single_lay.addWidget(_subrow(_tr("RGB"), [
+        _labeled(_tr("Rendering"), dialog.s2_rgb_render_combo, 70),
+        dialog.s2_btn_rgb_preview,
+        dialog.s2_btn_rgb_download,
+    ]))
 
-    # VI controls — index choice + color ramp.
-    vi_page = QWidget()
-    vi_page.setStyleSheet("background: transparent;")
-    vi_page_lay = QHBoxLayout(vi_page)
-    vi_page_lay.setContentsMargins(0, 0, 0, 0)
-    vi_page_lay.setSpacing(12)
+    # --- Vegetation index ---
     dialog.s2_vi_index_combo = QComboBox()
     _prepare_field(dialog.s2_vi_index_combo, 30)
-    dialog.s2_vi_index_combo.setMinimumWidth(120)
+    dialog.s2_vi_index_combo.setMinimumWidth(76)
     dialog.s2_vi_index_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
     for name in INDEX_ORDER:
         dialog.s2_vi_index_combo.addItem(name, name)
@@ -608,38 +615,24 @@ def _build_results_tab(dialog, parent):
     dialog.s2_vi_index_combo.view().setStyleSheet(_POPUP_VIEW_STYLE)
     dialog.s2_vi_ramp_combo = QComboBox()
     _prepare_field(dialog.s2_vi_ramp_combo, 30)
-    dialog.s2_vi_ramp_combo.setMinimumWidth(120)
+    dialog.s2_vi_ramp_combo.setMinimumWidth(90)
     dialog.s2_vi_ramp_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
     dialog.s2_vi_ramp_combo.addItems(_COLOR_RAMPS)
+    dialog.s2_vi_ramp_combo.setCurrentText("RdYlGn")
     dialog.s2_vi_ramp_combo.view().setStyleSheet(_POPUP_VIEW_STYLE)
-    vi_page_lay.addWidget(_labeled(_tr("Index"), dialog.s2_vi_index_combo, 44))
-    vi_page_lay.addWidget(_labeled(_tr("Color Ramp"), dialog.s2_vi_ramp_combo, 80))
-    vi_page_lay.addStretch(1)
+    dialog.s2_btn_vi_preview = QPushButton(_tr("Preview"))
+    dialog.s2_btn_vi_preview.setFixedHeight(30)
+    dialog.s2_btn_vi_preview.setStyleSheet(STYLE_BTN_PRIMARY)
+    dialog.s2_btn_vi_download = QPushButton(_tr("Download & Preview").replace("&", "&&"))
+    dialog.s2_btn_vi_download.setFixedHeight(30)
+    dialog.s2_btn_vi_download.setStyleSheet(STYLE_BTN_SECONDARY)
+    single_lay.addWidget(_subrow(_tr("INDEX"), [
+        _labeled(_tr("Index"), dialog.s2_vi_index_combo, 44),
+        _labeled(_tr("Color Ramp"), dialog.s2_vi_ramp_combo, 80),
+        dialog.s2_btn_vi_preview,
+        dialog.s2_btn_vi_download,
+    ]))
 
-    # Swap the type-specific controls without leaving gaps in the row.
-    type_stack = QStackedWidget()
-    type_stack.setStyleSheet("QStackedWidget { background: transparent; border: none; }")
-    type_stack.addWidget(rgb_page)
-    type_stack.addWidget(vi_page)
-    type_stack.setFixedHeight(34)
-    dialog.s2_output_stack = type_stack
-    dialog.s2_output_type_combo.currentIndexChanged.connect(type_stack.setCurrentIndex)
-
-    # One shared Preview / Download pair for both output types.
-    dialog.s2_btn_preview = QPushButton(_tr("Preview"))
-    dialog.s2_btn_preview.setFixedHeight(30)
-    dialog.s2_btn_preview.setStyleSheet(STYLE_BTN_PRIMARY)
-    dialog.s2_btn_download_preview = QPushButton(_tr("Download & Preview").replace("&", "&&"))
-    dialog.s2_btn_download_preview.setFixedHeight(30)
-    dialog.s2_btn_download_preview.setStyleSheet(STYLE_BTN_SECONDARY)
-
-    single_lay.addWidget(_flow([
-        _labeled(_tr("Date"), dialog.s2_result_date_combo, 34),
-        _labeled(_tr("Output"), dialog.s2_output_type_combo, 56),
-        type_stack,
-        dialog.s2_btn_preview,
-        dialog.s2_btn_download_preview,
-    ], spacing=12))
     lay.addWidget(single_panel)
 
     # --- Synthetic composite --------------------------------------------
@@ -665,6 +658,7 @@ def _build_results_tab(dialog, parent):
     dialog.s2_composite_ramp_combo.setMinimumWidth(200)
     dialog.s2_composite_ramp_combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
     dialog.s2_composite_ramp_combo.addItems(_COLOR_RAMPS)
+    dialog.s2_composite_ramp_combo.setCurrentText("RdYlGn")
     dialog.s2_composite_ramp_combo.view().setStyleSheet(_POPUP_VIEW_STYLE)
 
     dialog.s2_btn_composite_preview = QPushButton(_tr("Preview Composite"))
@@ -866,9 +860,9 @@ def setup_optical_page(dialog, page):
       s2_web_view, s2_btn_adjust_filter, s2_btn_filter_dates, s2_btn_open_browser,
       s2_btn_download_csv, s2_btn_batch_download,
       s2_chk_smoothing, s2_smooth_window, s2_smooth_polyorder,
-      s2_result_date_combo, s2_output_type_combo, s2_output_stack,
-      s2_rgb_render_combo, s2_vi_index_combo, s2_vi_ramp_combo,
-      s2_btn_preview, s2_btn_download_preview,
+      s2_result_date_combo,
+      s2_rgb_render_combo, s2_btn_rgb_preview, s2_btn_rgb_download,
+      s2_vi_index_combo, s2_vi_ramp_combo, s2_btn_vi_preview, s2_btn_vi_download,
       s2_composite_metric_combo, s2_composite_ramp_combo,
       s2_btn_composite_preview, s2_btn_composite_download,
       s2_chk_climate_precip, s2_chk_climate_tmin, s2_chk_climate_tmax,

--- a/view/optical_filter_dialog.py
+++ b/view/optical_filter_dialog.py
@@ -98,8 +98,9 @@ class OpticalFilterDialog(QDialog):
 
         intro = QLabel(
             _tr(
-                "Adjust how the cached image series is filtered. The plot updates "
-                "when you click OK — no new Earth Engine request is made."
+                "Three independent filters narrow the cached image series. Each "
+                "card notes which direction is stricter. The plot updates when "
+                "you click OK — no new Earth Engine request is made."
             )
         )
         intro.setWordWrap(True)
@@ -119,6 +120,7 @@ class OpticalFilterDialog(QDialog):
         body.setSpacing(14)
 
         body.addWidget(self._build_cloud_section())
+        body.addWidget(self._build_valid_section())
         body.addWidget(self._build_coverage_section())
         body.addStretch(1)
 
@@ -190,63 +192,71 @@ class OpticalFilterDialog(QDialog):
         row.addWidget(value_lbl)
         return row
 
-    def _build_cloud_section(self):
-        frame, lay = self._section(_tr("CLOUD COVER (SCENE)"))
-        lay.addWidget(self._explain(_tr(
-            "Drop scenes whose tile-level cloud cover (CLOUDY_PIXEL_PERCENTAGE, "
-            "from the image metadata) exceeds this limit. Lower values keep only "
-            "clearer scenes. The per-pixel and AOI-local filtering is driven by "
-            "the SCL classes below."
-        )))
+    def _strict_hint(self, text):
+        lbl = QLabel(text)
+        lbl.setWordWrap(True)
+        lbl.setStyleSheet("color: #b26a00; font-size: 10px; font-weight: bold;")
+        return lbl
 
-        lay.addWidget(QLabel(_tr("Max scene cloud %")))
-        self.cloud_scene_slider = self._pct_slider(
-            DEFAULT_FILTER_SETTINGS["cloud_scene_max"]
+    def _build_slider_section(self, title, explain, hint, attr, default):
+        """One self-contained filter card: title, explanation, slider, and a
+        strictness hint. The slider/value widgets are exposed as ``<attr>_slider``
+        / ``<attr>_value`` so get_settings / set_settings can reach them."""
+        frame, lay = self._section(title)
+        lay.addWidget(self._explain(explain))
+
+        slider = self._pct_slider(default)
+        value = QLabel(f"{default}%")
+        lay.addLayout(self._slider_row(slider, value))
+        lay.addWidget(self._strict_hint(hint))
+
+        slider.valueChanged.connect(
+            lambda v: (value.setText(f"{v}%"), self._emit())
         )
-        self.cloud_scene_value = QLabel(
-            f"{DEFAULT_FILTER_SETTINGS['cloud_scene_max']}%"
-        )
-        lay.addLayout(self._slider_row(self.cloud_scene_slider, self.cloud_scene_value))
-        self.cloud_scene_slider.valueChanged.connect(
-            lambda v: (self.cloud_scene_value.setText(f"{v}%"), self._emit())
-        )
+        setattr(self, attr + "_slider", slider)
+        setattr(self, attr + "_value", value)
         return frame
+
+    def _build_cloud_section(self):
+        return self._build_slider_section(
+            _tr("SCENE CLOUD COVER · MAX %"),
+            _tr(
+                "Tile-level cloud cover (CLOUDY_PIXEL_PERCENTAGE from image "
+                "metadata). Sentinel-2 scenes are 100×100 km tiles, so this is "
+                "whole-tile cloudiness — not the cloud inside your AOI. For local "
+                "conditions, use the Valid pixels filter."
+            ),
+            _tr("↓  Lower = stricter — keeps only clearer scenes"),
+            "cloud_scene",
+            DEFAULT_FILTER_SETTINGS["cloud_scene_max"],
+        )
+
+    def _build_valid_section(self):
+        return self._build_slider_section(
+            _tr("VALID PIXELS IN AOI · MIN %"),
+            _tr(
+                "Share of the AOI covered by valid (unmasked) pixels, per the SCL "
+                "classes chosen on the Inputs tab. Measured inside your AOI, so it "
+                "reflects local cloud and shadow better than scene cloud cover."
+            ),
+            _tr("↑  Higher = stricter — demands cleaner pixels in the AOI"),
+            "valid_pixel",
+            DEFAULT_FILTER_SETTINGS["valid_pixel_min"],
+        )
 
     def _build_coverage_section(self):
-        frame, lay = self._section(_tr("VALID PIXELS, COVERAGE & DUPLICATES"))
-        lay.addWidget(self._explain(_tr(
-            "Drop a date when valid (unmasked) pixels cover less than this share "
-            "of the AOI. Valid pixels are defined by the SCL mask chosen on the "
-            "Inputs tab; this slider only re-thresholds the cached counts."
-        )))
-        lay.addWidget(QLabel(_tr("Min valid pixels in AOI %")))
-        self.valid_pixel_slider = self._pct_slider(
-            DEFAULT_FILTER_SETTINGS["valid_pixel_min"]
+        return self._build_slider_section(
+            _tr("AOI FOOTPRINT COVERAGE · MIN %"),
+            _tr(
+                "How much of the AOI the scene's footprint overlaps. High "
+                "thresholds (e.g. 90%) ensure scenes that cover the whole AOI; "
+                "large or irregular AOIs spanning several tiles may rarely reach "
+                "high values."
+            ),
+            _tr("↑  Higher = stricter — requires fuller AOI coverage"),
+            "coverage",
+            DEFAULT_FILTER_SETTINGS["coverage_min"],
         )
-        self.valid_pixel_value = QLabel(
-            f"{DEFAULT_FILTER_SETTINGS['valid_pixel_min']}%"
-        )
-        lay.addLayout(self._slider_row(self.valid_pixel_slider, self.valid_pixel_value))
-        self.valid_pixel_slider.valueChanged.connect(
-            lambda v: (self.valid_pixel_value.setText(f"{v}%"), self._emit())
-        )
-
-        lay.addWidget(self._explain(_tr(
-            "Require each scene's footprint to cover at least this share of the "
-            "AOI."
-        )))
-        lay.addWidget(QLabel(_tr("Min AOI coverage %")))
-        self.coverage_slider = self._pct_slider(
-            DEFAULT_FILTER_SETTINGS["coverage_min"]
-        )
-        self.coverage_value = QLabel(
-            f"{DEFAULT_FILTER_SETTINGS['coverage_min']}%"
-        )
-        lay.addLayout(self._slider_row(self.coverage_slider, self.coverage_value))
-        self.coverage_slider.valueChanged.connect(
-            lambda v: (self.coverage_value.setText(f"{v}%"), self._emit())
-        )
-        return frame
 
     # -- behavior ---------------------------------------------------------
     def _emit(self):

--- a/view/optical_filter_dialog.py
+++ b/view/optical_filter_dialog.py
@@ -32,6 +32,17 @@ def _tr(text):
     return QCoreApplication.translate("RAVI", text)
 
 
+# Legacy default thresholds (from ravi_dialog_base.ui sliders):
+#   cloud_scene_max  <- total_pixel_limit (40)  -> keep cloud_pct <= 40
+#   valid_pixel_min  <- local_pixel_limit (80)  -> keep valid_pixel_pct >= 80
+#   coverage_min     <- aio_cover         (90)  -> keep coverage_pct >= 90
+DEFAULT_FILTER_SETTINGS = {
+    "cloud_scene_max": 40,
+    "valid_pixel_min": 80,
+    "coverage_min": 90,
+}
+
+
 _DIALOG_STYLE = (
     "QDialog { background-color: #ffffff; color: #212121; }"
     "QLabel { background: transparent; border: none; }"
@@ -52,15 +63,16 @@ QSlider::handle:horizontal:hover { background: #15532d; }
 class OpticalFilterDialog(QDialog):
     """Popup that adjusts the optical time-series filter client-side.
 
-    ``filter_changed`` carries the full settings dict (see :meth:`get_settings`)
-    and fires on every change so the plot can refresh live. ``dates`` is the
-    list of available acquisition dates used by the per-date checklist; it may
-    be empty before a series has been generated.
+    Filters are applied to the plot only when the user clicks OK. While the
+    sliders move, ``count_fn`` (if given) is called with the current settings
+    to show how many cached images would pass -- a cheap row count, not a plot
+    re-render. ``filter_changed`` still fires on every change for any listener
+    that wants it.
     """
 
     filter_changed = pyqtSignal(dict)
 
-    def __init__(self, settings=None, parent=None):
+    def __init__(self, settings=None, count_fn=None, parent=None):
         super().__init__(parent)
         self.setWindowTitle(_tr("Adjust Filter"))
         self.setMinimumWidth(480)
@@ -69,12 +81,14 @@ class OpticalFilterDialog(QDialog):
         self.setStyleSheet(_DIALOG_STYLE)
 
         self._initial = settings
+        self._count_fn = count_fn
         self._building = True
 
         self._build_ui()
         if settings:
             self.set_settings(settings)
         self._building = False
+        self._update_count()
 
     # -- construction -----------------------------------------------------
     def _build_ui(self):
@@ -84,8 +98,8 @@ class OpticalFilterDialog(QDialog):
 
         intro = QLabel(
             _tr(
-                "Adjust how the cached image series is filtered. Changes update "
-                "the plot immediately — no new Earth Engine request is made."
+                "Adjust how the cached image series is filtered. The plot updates "
+                "when you click OK — no new Earth Engine request is made."
             )
         )
         intro.setWordWrap(True)
@@ -110,6 +124,13 @@ class OpticalFilterDialog(QDialog):
 
         scroll.setWidget(content)
         main.addWidget(scroll, 1)
+
+        self.count_label = QLabel("")
+        self.count_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.count_label.setStyleSheet(
+            "color: #1b6b39; font-size: 12px; font-weight: bold;"
+        )
+        main.addWidget(self.count_label)
 
         button_box = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok
@@ -179,8 +200,12 @@ class OpticalFilterDialog(QDialog):
         )))
 
         lay.addWidget(QLabel(_tr("Max scene cloud %")))
-        self.cloud_scene_slider = self._pct_slider(100)
-        self.cloud_scene_value = QLabel("100%")
+        self.cloud_scene_slider = self._pct_slider(
+            DEFAULT_FILTER_SETTINGS["cloud_scene_max"]
+        )
+        self.cloud_scene_value = QLabel(
+            f"{DEFAULT_FILTER_SETTINGS['cloud_scene_max']}%"
+        )
         lay.addLayout(self._slider_row(self.cloud_scene_slider, self.cloud_scene_value))
         self.cloud_scene_slider.valueChanged.connect(
             lambda v: (self.cloud_scene_value.setText(f"{v}%"), self._emit())
@@ -195,8 +220,12 @@ class OpticalFilterDialog(QDialog):
             "Inputs tab; this slider only re-thresholds the cached counts."
         )))
         lay.addWidget(QLabel(_tr("Min valid pixels in AOI %")))
-        self.valid_pixel_slider = self._pct_slider(0)
-        self.valid_pixel_value = QLabel("0%")
+        self.valid_pixel_slider = self._pct_slider(
+            DEFAULT_FILTER_SETTINGS["valid_pixel_min"]
+        )
+        self.valid_pixel_value = QLabel(
+            f"{DEFAULT_FILTER_SETTINGS['valid_pixel_min']}%"
+        )
         lay.addLayout(self._slider_row(self.valid_pixel_slider, self.valid_pixel_value))
         self.valid_pixel_slider.valueChanged.connect(
             lambda v: (self.valid_pixel_value.setText(f"{v}%"), self._emit())
@@ -207,8 +236,12 @@ class OpticalFilterDialog(QDialog):
             "AOI."
         )))
         lay.addWidget(QLabel(_tr("Min AOI coverage %")))
-        self.coverage_slider = self._pct_slider(0)
-        self.coverage_value = QLabel("0%")
+        self.coverage_slider = self._pct_slider(
+            DEFAULT_FILTER_SETTINGS["coverage_min"]
+        )
+        self.coverage_value = QLabel(
+            f"{DEFAULT_FILTER_SETTINGS['coverage_min']}%"
+        )
         lay.addLayout(self._slider_row(self.coverage_slider, self.coverage_value))
         self.coverage_slider.valueChanged.connect(
             lambda v: (self.coverage_value.setText(f"{v}%"), self._emit())
@@ -219,7 +252,16 @@ class OpticalFilterDialog(QDialog):
     def _emit(self):
         if self._building:
             return
+        self._update_count()
         self.filter_changed.emit(self.get_settings())
+
+    def _update_count(self):
+        """Show how many cached images pass the current thresholds."""
+        if self._count_fn is None:
+            self.count_label.setText("")
+            return
+        n = self._count_fn(self.get_settings())
+        self.count_label.setText(_tr("%d images match") % n)
 
     def _on_cancel(self):
         if self._initial is not None:
@@ -238,7 +280,13 @@ class OpticalFilterDialog(QDialog):
     def set_settings(self, settings):
         """Apply a previously captured settings dict to the widgets."""
         self._building = True
-        self.cloud_scene_slider.setValue(settings.get("cloud_scene_max", 100))
-        self.valid_pixel_slider.setValue(settings.get("valid_pixel_min", 0))
-        self.coverage_slider.setValue(settings.get("coverage_min", 0))
+        self.cloud_scene_slider.setValue(
+            settings.get("cloud_scene_max", DEFAULT_FILTER_SETTINGS["cloud_scene_max"])
+        )
+        self.valid_pixel_slider.setValue(
+            settings.get("valid_pixel_min", DEFAULT_FILTER_SETTINGS["valid_pixel_min"])
+        )
+        self.coverage_slider.setValue(
+            settings.get("coverage_min", DEFAULT_FILTER_SETTINGS["coverage_min"])
+        )
         self._building = False

--- a/view/optical_filter_dialog.py
+++ b/view/optical_filter_dialog.py
@@ -14,7 +14,6 @@ in the time-series controls on the Results tab, not here.
 
 from qgis.PyQt.QtCore import Qt, QCoreApplication, pyqtSignal
 from qgis.PyQt.QtWidgets import (
-    QCheckBox,
     QDialog,
     QDialogButtonBox,
     QFrame,
@@ -205,7 +204,7 @@ class OpticalFilterDialog(QDialog):
 
         lay.addWidget(self._explain(_tr(
             "Require each scene's footprint to cover at least this share of the "
-            "AOI, and optionally keep only one image per acquisition date."
+            "AOI."
         )))
         lay.addWidget(QLabel(_tr("Min AOI coverage %")))
         self.coverage_slider = self._pct_slider(0)
@@ -214,12 +213,6 @@ class OpticalFilterDialog(QDialog):
         self.coverage_slider.valueChanged.connect(
             lambda v: (self.coverage_value.setText(f"{v}%"), self._emit())
         )
-
-        self.chk_unique_day = QCheckBox(_tr("Keep one image per date"))
-        self.chk_unique_day.setChecked(True)
-        self.chk_unique_day.setStyleSheet(STYLE_CHECKBOX)
-        self.chk_unique_day.stateChanged.connect(lambda _s: self._emit())
-        lay.addWidget(self.chk_unique_day)
         return frame
 
     # -- behavior ---------------------------------------------------------
@@ -240,7 +233,6 @@ class OpticalFilterDialog(QDialog):
             "cloud_scene_max": self.cloud_scene_slider.value(),
             "valid_pixel_min": self.valid_pixel_slider.value(),
             "coverage_min": self.coverage_slider.value(),
-            "unique_day": self.chk_unique_day.isChecked(),
         }
 
     def set_settings(self, settings):
@@ -249,5 +241,4 @@ class OpticalFilterDialog(QDialog):
         self.cloud_scene_slider.setValue(settings.get("cloud_scene_max", 100))
         self.valid_pixel_slider.setValue(settings.get("valid_pixel_min", 0))
         self.coverage_slider.setValue(settings.get("coverage_min", 0))
-        self.chk_unique_day.setChecked(settings.get("unique_day", True))
         self._building = False

--- a/workers/batch_download_worker.py
+++ b/workers/batch_download_worker.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Generic sequential batch-download worker.
+
+Downloads one item per date off the UI thread, emitting progress so a
+QProgressDialog can track it. The per-date work is injected as a
+``download_one(date) -> path`` callable, so the same worker serves any page
+(SAR, optical, …) without knowing the service details. The callable runs on
+this thread and must not touch Qt widgets.
+"""
+
+from qgis.PyQt.QtCore import QThread, pyqtSignal, QMutex
+
+
+class BatchDownloadWorker(QThread):
+    progress = pyqtSignal(int, int, str)        # current, total, date
+    finished = pyqtSignal(int, int, list)        # successful, total, paths
+    cancelled = pyqtSignal(int, int, list)       # successful, total, paths
+    failed = pyqtSignal(str)
+
+    def __init__(self, dates, download_one):
+        super().__init__()
+        self._dates = list(dates)
+        self._download_one = download_one
+        self._cancel_requested = False
+        self._mutex = QMutex()
+
+    def request_cancel(self):
+        self._mutex.lock()
+        self._cancel_requested = True
+        self._mutex.unlock()
+
+    def _cancelled(self) -> bool:
+        self._mutex.lock()
+        flag = self._cancel_requested
+        self._mutex.unlock()
+        return flag
+
+    def run(self):
+        successful = 0
+        total = len(self._dates)
+        paths = []
+
+        for index, date in enumerate(self._dates, start=1):
+            if self._cancelled():
+                self.cancelled.emit(successful, total, paths)
+                return
+
+            self.progress.emit(index, total, str(date))
+            try:
+                paths.append(self._download_one(date))
+                successful += 1
+            except Exception:
+                pass
+
+        self.finished.emit(successful, total, paths)


### PR DESCRIPTION
## Summary
Builds out the Optical (Sentinel-2) results experience and refreshes the Auth page.

### Optical
- Plot the index time series on the results page (was console print); post-auth now lands on the Optical page.
- `coverage_pct`: documented the geometry/tile footprint limitation; reverted to the cheaper legacy geometry metric.
- Always keep one image per acquisition date (best AOI coverage, cloud tiebreaker); removed the dead UI toggle.
- Adjust Filter dialog: live image count, apply-on-OK (no slow live re-render); one filter per card with strictness hints; legacy default thresholds (cloud ≤40, valid ≥80, coverage ≥90).
- Filter dates implemented (mirrors SAR); Adjust Filter OK overrides the date selection and rebuilds the single-image dropdown.
- Time-series exports: Open in Browser, Export CSV (current selection), Batch Download — raw multispectral S2 clipped to AOI + buffer, via a shared generic `BatchDownloadWorker`; images load as true-colour (B4/B3/B2) with a 2–98% cumulative-cut stretch.
- Single-date image section split into RGB / Vegetation-index subsections with per-output Preview/Download buttons (UI only, not yet wired); RdYlGn default ramp.

### Auth
- Two-column welcome (RAVI story + feature overview, author/FARM links) beside the sign-in card, status, prerequisites and download folder; independent scroll.
- Fixed broken author links (shorturl → LinkedIn) here and in intro.html / intro_pt.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)