### PR TITLE
feat(sysi): implement GEOS3 bare-soil composite backend

### DIFF
--- a/controllers/sysi_ctrl.py
+++ b/controllers/sysi_ctrl.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+"""
+Controller for the SYSI (Synthetic Soil Image) page.
+
+Wires the UI inputs in ``view/sysi.py`` to the GEOS3 pipeline implemented in
+``services/sysi_service.py``.  Follows the same patterns as ``sar_ctrl.py``:
+  • AOI is extracted on the main thread and passed to a QThread worker.
+  • The worker emits ``finished``/``failed``; the controller loads the result
+    into QGIS and updates the UI.
+  • The generate button is disabled while the worker is running to prevent
+    concurrent submissions.
+"""
+
+import os
+import tempfile
+
+from qgis.PyQt.QtCore import Qt, QCoreApplication
+from qgis.core import (
+    QgsContrastEnhancement,
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsLayerTreeLayer,
+    QgsMultiBandColorRenderer,
+    QgsProject,
+    QgsRasterLayer,
+)
+
+from ..services.aoi_service import AOIService
+from ..workers.sysi_worker import SYSIWorker
+from ..managers.settings_manager import SettingsManager
+from ..tools.aoi_draw_tool import start_draw_aoi
+
+try:
+    WAIT_CURSOR = Qt.CursorShape.WaitCursor
+except AttributeError:
+    WAIT_CURSOR = Qt.WaitCursor
+
+_CANVAS_SCALE_FACTOR = 1.5
+
+
+def _tr(text):
+    return QCoreApplication.translate("RAVI", text)
+
+
+# Band order in the exported GeoTIFF: Blue=1, Green=2, Red=3, ...
+# Natural-colour RGB: Red=band3, Green=band2, Blue=band1
+_RGB_RED_BAND = 3
+_RGB_GREEN_BAND = 2
+_RGB_BLUE_BAND = 1
+
+
+class SYSICtrl:
+    """Handles user interactions on the SYSI page."""
+
+    def __init__(self, dialog, interface=None, gee_service=None):
+        self.dialog = dialog
+        self.interface = interface
+        self.gee_service = gee_service
+
+        self.aoi = None
+        self._worker: SYSIWorker | None = None
+        self._draw_tool = None
+        self._generate_btn_text: str | None = None
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle
+    # ------------------------------------------------------------------
+
+    def _release_worker(self):
+        if self._worker is not None:
+            self._worker.deleteLater()
+            self._worker = None
+
+    # ------------------------------------------------------------------
+    # AOI helpers
+    # ------------------------------------------------------------------
+
+    def handle_draw_aoi(self):
+        """Toggle rectangular AOI drawing on the canvas."""
+        canvas = self.interface.mapCanvas()
+        if self._draw_tool is not None and canvas.mapTool() is self._draw_tool:
+            canvas.unsetMapTool(self._draw_tool)
+            self._draw_tool = None
+            return
+        self._draw_tool = start_draw_aoi(
+            self.interface,
+            self.dialog.sysi_layer_combo,
+            self.dialog.sysi_btn_draw_aoi,
+        )
+
+    def handle_layer_changed(self, layer=None):
+        """Zoom the map canvas to the newly selected AOI layer."""
+        if layer is None:
+            layer = self.dialog.sysi_layer_combo.currentLayer()
+        if not layer or not layer.isValid() or not self.interface:
+            return
+        canvas = self.interface.mapCanvas()
+        transform = QgsCoordinateTransform(
+            layer.crs(),
+            canvas.mapSettings().destinationCrs(),
+            QgsProject.instance(),
+        )
+        extent = transform.transformBoundingBox(layer.extent())
+        extent.scale(_CANVAS_SCALE_FACTOR)
+        canvas.setExtent(extent)
+        canvas.refresh()
+
+    def _download_aoi(self):
+        """Return the AOI expanded (or cropped) by the buffer slider value.
+
+        Values within ±3 m are snapped to 0 (dead zone) to avoid accidental
+        tiny offsets.  Returns the original AOI when the slider is at 0 or
+        when no AOI has been set yet.
+        """
+        slider = getattr(self.dialog, "sysi_buffer_slider", None)
+        raw = slider.value() if slider is not None else 0
+        meters = 0 if -3 <= raw <= 3 else raw
+        if not meters or self.aoi is None:
+            return self.aoi
+        return self.aoi.map(lambda feature: feature.buffer(meters).bounds())
+
+    # ------------------------------------------------------------------
+    # Generate SYSI
+    # ------------------------------------------------------------------
+
+    def _read_params(self):
+        """Collect all UI parameter values into a dict."""
+        months = [
+            m for m, chk in self.dialog.sysi_month_checks.items()
+            if chk.isChecked()
+        ]
+
+        return {
+            "start_date": self.dialog.sysi_date_start.date().toString("yyyy-MM-dd"),
+            "end_date": self.dialog.sysi_date_end.date().toString("yyyy-MM-dd"),
+            "cloud_threshold": self.dialog.sysi_cloud_slider.value(),
+            "ndvi_thres": [
+                self.dialog.sysi_ndvi_range_slider.low(),
+                self.dialog.sysi_ndvi_range_slider.high(),
+            ],
+            "nbr_thres": [
+                self.dialog.sysi_nbr_range_slider.low(),
+                self.dialog.sysi_nbr_range_slider.high(),
+            ],
+            "selected_months": months,
+        }
+
+    def handle_generate_sysi(self):
+        """Validate inputs and launch the GEOS3 pipeline worker."""
+        if self._worker is not None and self._worker.isRunning():
+            return
+
+        if self.gee_service and not self.gee_service.is_authenticated:
+            self.dialog.pop_message(
+                _tr(
+                    "Authentication is required to generate SYSI data. "
+                    "Please go to the Auth page and validate your Google Cloud "
+                    "project ID."
+                ),
+                "warning",
+            )
+            return
+
+        layer = self.dialog.sysi_layer_combo.currentLayer()
+        if not layer:
+            self.dialog.pop_message(_tr("Select an AOI layer."), "warning")
+            return
+
+        params = self._read_params()
+
+        if not params["selected_months"]:
+            self.dialog.pop_message(
+                _tr("Select at least one month."), "warning"
+            )
+            return
+
+        start_qdate = self.dialog.sysi_date_start.date()
+        end_qdate = self.dialog.sysi_date_end.date()
+        if start_qdate >= end_qdate:
+            self.dialog.pop_message(
+                _tr("End date must be after start date."), "warning"
+            )
+            return
+
+        try:
+            aoi, _bbox = AOIService.get_ee_feature_colection_from_layer(
+                layer, use_selected_features=False
+            )
+        except Exception as exc:
+            self.dialog.pop_message(str(exc), "warning")
+            return
+
+        self.aoi = aoi
+        params["output_folder"] = (
+            SettingsManager.load_download_folder() or tempfile.gettempdir()
+        )
+        params["label"] = "SYSI"
+
+        self._set_generate_busy(True)
+
+        self._worker = SYSIWorker(self._download_aoi(), params)
+        self._worker.finished.connect(self._on_sysi_done)
+        self._worker.failed.connect(self._on_sysi_failed)
+        self._worker.start()
+
+    def _set_generate_busy(self, busy: bool):
+        btn = self.dialog.sysi_btn_generate
+        if busy:
+            self._generate_btn_text = self._generate_btn_text or btn.text()
+            btn.setText(_tr("Generating…"))
+        else:
+            btn.setText(self._generate_btn_text or btn.text())
+        btn.setEnabled(not busy)
+
+    def _on_sysi_done(self, output_path: str, label: str):
+        self._set_generate_busy(False)
+        self._release_worker()
+
+        self._load_sysi_to_qgis(output_path, label)
+
+        if self.interface:
+            filename = os.path.basename(output_path)
+            self.interface.messageBar().pushMessage(
+                "RAVI",
+                _tr("SYSI '%s' generated and loaded into QGIS.") % filename,
+            )
+
+    def _on_sysi_failed(self, message: str):
+        self._set_generate_busy(False)
+        self._release_worker()
+        self.dialog.pop_message(message, "warning")
+
+    # ------------------------------------------------------------------
+    # QGIS layer loading
+    # ------------------------------------------------------------------
+
+    def _load_sysi_to_qgis(self, path: str, label: str):
+        """Load the SYSI GeoTIFF as a natural-colour RGB layer in QGIS.
+
+        Band layout in the exported file:
+          1 Blue · 2 Green · 3 Red · 4 Rededge2 · 5 NIR
+          6 SWIR1 · 7 SWIR2 · 8 NDVI · 9 NBR2
+
+        The renderer uses R=3, G=2, B=1 (natural colour) with a 2–98 %
+        cumulative-cut contrast enhancement, matching the pattern used by
+        ``SARRenderer._create_rgb_composite``.
+        """
+        layer = QgsRasterLayer(path, label)
+        if not layer.isValid():
+            self.dialog.pop_message(
+                _tr("Failed to load SYSI raster into QGIS."), "warning"
+            )
+            return
+
+        layer.setCrs(QgsCoordinateReferenceSystem("EPSG:4326"))
+
+        renderer = QgsMultiBandColorRenderer(
+            layer.dataProvider(),
+            _RGB_RED_BAND,
+            _RGB_GREEN_BAND,
+            _RGB_BLUE_BAND,
+        )
+
+        try:
+            provider = layer.dataProvider()
+            from qgis.utils import iface as _iface
+            canvas = _iface.mapCanvas() if _iface else None
+            extent = canvas.extent() if canvas else layer.extent()
+            if not extent.intersects(layer.extent()):
+                extent = layer.extent()
+
+            for band_idx, set_fn in [
+                (_RGB_RED_BAND, renderer.setRedContrastEnhancement),
+                (_RGB_GREEN_BAND, renderer.setGreenContrastEnhancement),
+                (_RGB_BLUE_BAND, renderer.setBlueContrastEnhancement),
+            ]:
+                min_max = provider.cumulativeCut(band_idx, 0.02, 0.98, extent, 250000)
+                ce = QgsContrastEnhancement(provider.dataType(band_idx))
+                ce.setContrastEnhancementAlgorithm(
+                    QgsContrastEnhancement.StretchToMinimumMaximum
+                )
+                ce.setMinimumValue(min_max[0])
+                ce.setMaximumValue(min_max[1])
+                set_fn(ce)
+        except Exception:
+            pass
+
+        layer.setRenderer(renderer)
+        QgsProject.instance().addMapLayer(layer, False)
+        root = QgsProject.instance().layerTreeRoot()
+        root.insertChildNode(0, QgsLayerTreeLayer(layer))
+        layer.triggerRepaint()

--- a/ravi.py
+++ b/ravi.py
@@ -149,6 +149,7 @@ class RAVI:
         from .controllers.auth_ctrl import AuthCtrl
         from .controllers.sar_ctrl import SARCtrl
         from .controllers.optical_ctrl import OpticalCtrl
+        from .controllers.sysi_ctrl import SYSICtrl
 
         self._services_ready = True
         self.gee_service = GEEService()
@@ -158,6 +159,7 @@ class RAVI:
         self.optical_ctrl = OpticalCtrl(
             self.dialog, self.interface, self.gee_service
         )
+        self.sysi_ctrl = SYSICtrl(self.dialog, self.interface, self.gee_service)
 
         saved_project_id = self.gee_service.get_saved_project_id()
         if saved_project_id:
@@ -254,6 +256,19 @@ class RAVI:
             self.sar_ctrl.handle_layer_changed
         )
 
+        self.dialog.sysi_btn_draw_aoi.clicked.connect(
+            self.sysi_ctrl.handle_draw_aoi
+        )
+        self.dialog.sysi_btn_hybrid_layer.clicked.connect(
+            self.dem_ctrl.handle_hybrid_layer
+        )
+        self.dialog.sysi_btn_generate.clicked.connect(
+            self.sysi_ctrl.handle_generate_sysi
+        )
+        self.dialog.sysi_layer_combo.layerChanged.connect(
+            self.sysi_ctrl.handle_layer_changed
+        )
+
         self.auth_ctrl.refresh_auth_status()
 
     def _on_extlibs_ready(self, success, error_msg):
@@ -274,7 +289,7 @@ class RAVI:
         """Display the plugin dialog and handle user interaction."""
         from . import extlibs_manager
 
-        if self.first_start:
+        if self.first_start or not hasattr(self, "dialog"):
             self.first_start = False
             self.dialog = RAVIDialog(self.interface.mainWindow())
 

--- a/services/sysi_service.py
+++ b/services/sysi_service.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+"""
+SYSI (Synthetic Soil Image) service.
+
+Implements the GEOS3 bare-soil composite pipeline for Sentinel-2 SR Harmonized
+imagery.  The pipeline is a faithful port of the validated logic in
+dev/08_sysi_soil_image.ipynb, with added empty-collection guards and
+consistent download/naming helpers that follow the SAR service conventions.
+
+GEOS3 bare-soil rule — a pixel is bare soil when ALL hold:
+  • NDVI within [ndvi_min, ndvi_max]          (low vegetation)
+  • NBR2 within [nbr_min, nbr_max]            (limits crop residue / NPV)
+  • VNSIR ≤ 0.9                               (visible-to-SWIR slope for soil)
+  • GRBL > 0  (Green > Blue)                  (rising visible slope)
+  • REGR > 0  (Red   > Green)                 (continues the rising slope)
+"""
+
+import os
+import tempfile
+
+import ee
+import requests
+
+try:
+    from osgeo import gdal
+except ImportError:
+    gdal = None
+
+
+# --- Constants ---------------------------------------------------------------
+
+# Raw Sentinel-2 band codes selected from S2_SR_HARMONIZED
+_S2_BAND_NAMES = ['B2', 'B3', 'B4', 'B6', 'B8', 'B11', 'B12', 'QA60']
+
+# Human-readable aliases (positional match with _S2_BAND_NAMES)
+_FRIENDLY_NAMES = ['Blue', 'Green', 'Red', 'Rededge2', 'NIR', 'SWIR1', 'SWIR2', 'QA60']
+
+# Bands rescaled to surface reflectance [0–1] (QA60 is kept for mask bookkeeping)
+_OPTICAL_BANDS = ['Blue', 'Green', 'Red', 'Rededge2', 'NIR', 'SWIR1', 'SWIR2', 'QA60']
+
+# Final export band order — matches the legacy bands_to_export list
+_BANDS_TO_EXPORT = ['Blue', 'Green', 'Red', 'Rededge2', 'NIR', 'SWIR1', 'SWIR2', 'NDVI', 'NBR2']
+
+# VNSIR threshold is fixed in the legacy implementation and not exposed to users
+_VNSIR_THRESHOLD = 0.9
+
+
+class SYSIService:
+    """Service layer for the GEOS3 bare-soil composite pipeline."""
+
+    # ------------------------------------------------------------------
+    # Private image-level helpers (mapped over the collection)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _mask_s2_clouds(image):
+        """QA60 cloud / cirrus mask — bits 10 (clouds) and 11 (cirrus)."""
+        qa = image.select('QA60')
+        cloud_bit = 1 << 10
+        cirrus_bit = 1 << 11
+        mask = (
+            qa.bitwiseAnd(cloud_bit).eq(0)
+            .And(qa.bitwiseAnd(cirrus_bit).eq(0))
+        )
+        return image.updateMask(mask)
+
+    @staticmethod
+    def _add_indexes(image):
+        """Compute NDVI, NBR2, GRBL, REGR from the renamed bands."""
+        ndvi = image.normalizedDifference(['NIR', 'Red']).rename('NDVI')
+        nbr2 = image.normalizedDifference(['SWIR1', 'SWIR2']).rename('NBR2')
+        # GRBL/REGR are computed before scale-factor application; the > 0
+        # condition is scale-invariant (Green > Blue ↔ GRBL > 0 at any scale).
+        grbl = image.select('Green').subtract(image.select('Blue')).rename('GRBL')
+        regr = image.select('Red').subtract(image.select('Green')).rename('REGR')
+        return (
+            image
+            .addBands(ndvi)
+            .addBands(nbr2)
+            .addBands(grbl)
+            .addBands(regr)
+        )
+
+    @staticmethod
+    def _apply_scale_factors(image):
+        """Divide optical + QA60 bands by 10 000 → surface reflectance [0–1]."""
+        optical = image.select(_OPTICAL_BANDS).divide(10000)
+        return image.addBands(optical, None, True)
+
+    @staticmethod
+    def _make_geos3_mapper(ndvi_thres, nbr_thres):
+        """Return a closure that adds the GEOS3 mask band to an image."""
+        def _add_geos3(image):
+            # VNSIR = 1 − (2·Red − Green − Blue + 3·(NIR − Red))
+            vnsir = ee.Image(1).subtract(
+                ee.Image(2).multiply(image.select('Red'))
+                .subtract(image.select('Green'))
+                .subtract(image.select('Blue'))
+                .add(
+                    ee.Image(3).multiply(
+                        image.select('NIR').subtract(image.select('Red'))
+                    )
+                )
+            )
+            geos3 = (
+                image.select('NDVI').gte(ndvi_thres[0])
+                .And(image.select('NDVI').lte(ndvi_thres[1]))
+                .And(image.select('NBR2').gte(nbr_thres[0]))
+                .And(image.select('NBR2').lte(nbr_thres[1]))
+                .And(vnsir.lte(_VNSIR_THRESHOLD))
+                .And(image.select('GRBL').gt(0))
+                .And(image.select('REGR').gt(0))
+            )
+            return image.addBands(geos3.rename('GEOS3'))
+        return _add_geos3
+
+    @staticmethod
+    def _mask_by_geos3(image):
+        """Keep only pixels where GEOS3 == 1; also drop black-border no-data."""
+        mask = (
+            image.select('GEOS3').eq(1)
+            .And(image.select('SWIR2').gte(0))
+            .And(image.select('Green').gte(0))
+            .And(image.select('Red').gte(0))
+            .And(image.select('Blue').gte(0))
+        )
+        return image.updateMask(mask)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def build_composite(
+        aoi,
+        start_date,
+        end_date,
+        cloud_threshold,
+        ndvi_thres,
+        nbr_thres,
+        selected_months,
+    ):
+        """Build a GEOS3 bare-soil composite ee.Image clipped to *aoi*.
+
+        Parameters
+        ----------
+        aoi : ee.FeatureCollection
+            Area of interest (may include a buffer applied by the controller).
+        start_date, end_date : str  (``'YYYY-MM-DD'``)
+        cloud_threshold : int
+            Maximum ``CLOUDY_PIXEL_PERCENTAGE`` for a scene to be included.
+        ndvi_thres : list[float, float]
+            ``[min, max]`` NDVI range for bare-soil pixels.
+        nbr_thres : list[float, float]
+            ``[min, max]`` NBR2 range for bare-soil pixels.
+        selected_months : list[int]
+            Calendar months (1–12) to include.
+
+        Returns
+        -------
+        ee.Image
+            9-band float32 composite (Blue, Green, Red, Rededge2, NIR,
+            SWIR1, SWIR2, NDVI, NBR2), clipped to *aoi*.
+
+        Raises
+        ------
+        RuntimeError
+            If the collection is empty after date/cloud or month filtering.
+        """
+        aoi_geometry = aoi.geometry()
+
+        collection = (
+            ee.ImageCollection('COPERNICUS/S2_SR_HARMONIZED')
+            .filterDate(start_date, end_date)
+            .filterBounds(aoi_geometry)
+            .filter(ee.Filter.lt('CLOUDY_PIXEL_PERCENTAGE', cloud_threshold))
+            .map(SYSIService._mask_s2_clouds)
+            .select(_S2_BAND_NAMES, _FRIENDLY_NAMES)
+        )
+
+        scene_count = collection.size().getInfo()
+        if scene_count == 0:
+            raise RuntimeError(
+                "No Sentinel-2 scenes found for the given date range and cloud "
+                "threshold. Try extending the date range or raising the cloud "
+                "threshold."
+            )
+
+        def _tag_month(image):
+            month = ee.Date(image.get('system:time_start')).get('month')
+            return image.set('month', month)
+
+        collection = (
+            collection
+            .map(_tag_month)
+            .filter(ee.Filter.inList('month', ee.List(selected_months)))
+        )
+
+        scene_count_after_months = collection.size().getInfo()
+        if scene_count_after_months == 0:
+            raise RuntimeError(
+                "No scenes found for the selected months. "
+                "Try enabling more months or extending the date range."
+            )
+
+        geos3_mapper = SYSIService._make_geos3_mapper(ndvi_thres, nbr_thres)
+
+        bare_soil_collection = (
+            collection
+            .map(SYSIService._add_indexes)
+            .map(SYSIService._apply_scale_factors)
+            .map(geos3_mapper)
+            .map(SYSIService._mask_by_geos3)
+        )
+
+        composite = (
+            bare_soil_collection
+            .median()
+            .select(_BANDS_TO_EXPORT)
+            .toFloat()
+            .clip(aoi_geometry)
+        )
+
+        return composite
+
+    @staticmethod
+    def download_composite(composite, aoi, output_folder=None):
+        """Download *composite* as a GeoTIFF and return the local file path.
+
+        Parameters
+        ----------
+        composite : ee.Image
+            Output of :meth:`build_composite`.
+        aoi : ee.FeatureCollection
+            Used to derive the download bounding box.
+        output_folder : str or None
+            Target directory.  Falls back to the system temp directory if
+            *output_folder* is ``None`` or does not exist.
+
+        Returns
+        -------
+        str
+            Absolute path to the downloaded GeoTIFF.
+        """
+        download_url = composite.getDownloadURL({
+            'scale': 10,
+            'region': aoi.geometry().bounds().getInfo(),
+            'format': 'GeoTIFF',
+            'crs': 'EPSG:4326',
+        })
+
+        response = requests.get(download_url, timeout=300)
+        if not response.ok:
+            raise RuntimeError(
+                "SYSI download failed (HTTP {}): {}".format(
+                    response.status_code, response.reason
+                )
+            )
+
+        target_dir = (
+            output_folder
+            if (output_folder and os.path.isdir(output_folder))
+            else tempfile.gettempdir()
+        )
+        output_path = SYSIService._get_unique_path(target_dir, "SYSI_composite.tiff")
+
+        with open(output_path, "wb") as fh:
+            fh.write(response.content)
+
+        SYSIService._set_band_names(output_path)
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Private utilities
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _set_band_names(file_path):
+        """Write human-readable band descriptions into the GeoTIFF metadata."""
+        if gdal is None:
+            return
+        try:
+            dataset = gdal.Open(file_path, gdal.GA_Update)
+            if dataset is None:
+                return
+            for i, name in enumerate(_BANDS_TO_EXPORT, start=1):
+                if i <= dataset.RasterCount:
+                    band = dataset.GetRasterBand(i)
+                    if band is not None:
+                        band.SetDescription(name)
+            dataset = None
+        except Exception:
+            pass
+
+    @staticmethod
+    def _get_unique_path(folder, filename):
+        candidate = os.path.join(folder, filename)
+        if not os.path.exists(candidate):
+            return candidate
+        basename, ext = os.path.splitext(filename)
+        counter = 1
+        while True:
+            candidate = os.path.join(folder, f"{basename}_{counter}{ext}")
+            if not os.path.exists(candidate):
+                return candidate
+            counter += 1

--- a/view/range_slider.py
+++ b/view/range_slider.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+"""
+Compact two-handle horizontal range slider.
+
+Renders a single track with a low handle (left) and a high handle (right).
+Value labels float above each handle.  Dragging either handle updates the
+corresponding boundary; handles cannot cross.
+
+Compatible with Qt 5 and Qt 6 (accessed through qgis.PyQt).
+"""
+
+from qgis.PyQt.QtCore import Qt, pyqtSignal, QRectF, QPointF
+from qgis.PyQt.QtGui import QPainter, QColor, QPen, QFont
+from qgis.PyQt.QtWidgets import QWidget, QSizePolicy
+
+# ---- Qt5 / Qt6 compat helpers -----------------------------------------------
+try:
+    _ANTIALIAS = QPainter.RenderHint.Antialiasing
+except AttributeError:
+    _ANTIALIAS = QPainter.Antialiasing  # type: ignore[attr-defined]
+
+try:
+    _NO_PEN = Qt.PenStyle.NoPen
+except AttributeError:
+    _NO_PEN = Qt.NoPen  # type: ignore[attr-defined]
+
+try:
+    _LEFT_BTN = Qt.MouseButton.LeftButton
+except AttributeError:
+    _LEFT_BTN = Qt.LeftButton  # type: ignore[attr-defined]
+
+try:
+    _ALIGN_LABEL = Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignBottom
+except AttributeError:
+    _ALIGN_LABEL = Qt.AlignHCenter | Qt.AlignBottom  # type: ignore[attr-defined]
+
+try:
+    _SIZE_EXPANDING = QSizePolicy.Policy.Expanding
+    _SIZE_FIXED = QSizePolicy.Policy.Fixed
+    _POINTING = Qt.CursorShape.PointingHandCursor
+    _SIZEHOR  = Qt.CursorShape.SizeHorCursor
+except AttributeError:
+    _SIZE_EXPANDING = QSizePolicy.Expanding      # type: ignore[attr-defined]
+    _SIZE_FIXED = QSizePolicy.Fixed              # type: ignore[attr-defined]
+    _POINTING = Qt.PointingHandCursor            # type: ignore[attr-defined]
+    _SIZEHOR  = Qt.SizeHorCursor                # type: ignore[attr-defined]
+
+
+def _event_x(event) -> float:
+    """Return the x coordinate of a QMouseEvent (Qt5 and Qt6 safe)."""
+    try:
+        return float(event.position().x())
+    except AttributeError:
+        return float(event.x())
+
+
+# ---- Colour constants --------------------------------------------------------
+_C_TRACK         = QColor("#e0e0e0")
+_C_RANGE         = QColor("#1b6b39")
+_C_RANGE_HOVER   = QColor("#23924d")   # brighter green on hover / press
+_C_HANDLE_BORDER = QColor("#ffffff")
+_C_LABEL         = QColor("#616161")
+
+
+class RangeSlider(QWidget):
+    """Horizontal slider with *low* and *high* handles for selecting a range.
+
+    Signals
+    -------
+    low_changed(float)
+        Emitted whenever the low boundary changes.
+    high_changed(float)
+        Emitted whenever the high boundary changes.
+
+    Properties
+    ----------
+    low() / high()
+        Current boundary values (rounded to *decimals* places).
+    set_low(v) / set_high(v)
+        Programmatically move a handle, clamped to [minimum, high] or
+        [low, maximum] respectively.
+    """
+
+    low_changed  = pyqtSignal(float)
+    high_changed = pyqtSignal(float)
+
+    # Geometry constants (pixels)
+    _LABEL_H = 16   # vertical space for floating value labels
+    _HR = 8         # handle radius (normal)
+    _HR_HOV = 10    # handle radius when hovered / pressed
+    _TH = 4         # track height
+    _PAD = 10       # horizontal padding so handles don't clip at edges
+    _BOT = 4        # bottom padding
+
+    def __init__(
+        self,
+        minimum: float,
+        maximum: float,
+        low: float,
+        high: float,
+        decimals: int = 2,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._min = float(minimum)
+        self._max = float(maximum)
+        self._low = float(low)
+        self._high = float(high)
+        self._decimals = decimals
+        self._pressed: str | None = None   # 'low' | 'high' | None
+        self._hovered: str | None = None   # 'low' | 'high' | None
+
+        fixed_h = self._LABEL_H + 2 * self._HR_HOV + self._BOT
+        self.setMinimumHeight(fixed_h)
+        self.setMaximumHeight(fixed_h)
+        self.setSizePolicy(_SIZE_EXPANDING, _SIZE_FIXED)
+        self.setCursor(_POINTING)
+        self.setMouseTracking(True)   # receive mouseMoveEvent without button held
+        self.setStyleSheet("background: transparent;")
+
+    # ------------------------------------------------------------------ values
+
+    def low(self) -> float:
+        return round(self._low, self._decimals)
+
+    def high(self) -> float:
+        return round(self._high, self._decimals)
+
+    def set_low(self, value: float):
+        v = max(self._min, min(self._high, float(value)))
+        if v != self._low:
+            self._low = v
+            self.update()
+            self.low_changed.emit(self.low())
+
+    def set_high(self, value: float):
+        v = min(self._max, max(self._low, float(value)))
+        if v != self._high:
+            self._high = v
+            self.update()
+            self.high_changed.emit(self.high())
+
+    # --------------------------------------------------------------- geometry
+
+    def _track_cy(self) -> float:
+        return self._LABEL_H + self._HR_HOV
+
+    def _val_to_x(self, val: float) -> float:
+        usable = self.width() - 2 * self._PAD
+        return self._PAD + (val - self._min) / (self._max - self._min) * usable
+
+    def _x_to_val(self, x: float) -> float:
+        usable = self.width() - 2 * self._PAD
+        ratio = (x - self._PAD) / usable
+        return self._min + ratio * (self._max - self._min)
+
+    def _clamped(self, v: float) -> float:
+        return max(self._min, min(self._max, v))
+
+    # --------------------------------------------------------------- hover
+
+    def _update_hover(self, x: float):
+        lx = self._val_to_x(self._low)
+        hx = self._val_to_x(self._high)
+        dl = abs(x - lx)
+        dh = abs(x - hx)
+        hit = self._HR_HOV + 4
+        if dh <= hit and dh <= dl:
+            new = 'high'
+        elif dl <= hit:
+            new = 'low'
+        else:
+            new = None
+        if new != self._hovered:
+            self._hovered = new
+            self.setCursor(_SIZEHOR if new is not None else _POINTING)
+            self.update()
+
+    # ---------------------------------------------------------------- painting
+
+    def paintEvent(self, _event):
+        painter = QPainter(self)
+        painter.setRenderHint(_ANTIALIAS)
+
+        cy  = self._track_cy()
+        lx  = self._val_to_x(self._low)
+        hx  = self._val_to_x(self._high)
+        th  = self._TH
+        pad = self._PAD
+
+        # --- background track ---
+        painter.setPen(_NO_PEN)
+        painter.setBrush(_C_TRACK)
+        painter.drawRoundedRect(
+            QRectF(pad, cy - th / 2, self.width() - 2 * pad, th), 2, 2
+        )
+
+        # --- filled range between handles ---
+        painter.setBrush(_C_RANGE)
+        painter.drawRoundedRect(QRectF(lx, cy - th / 2, hx - lx, th), 2, 2)
+
+        # --- handles: low first so high renders on top when overlapping ---
+        for px, side in [(lx, 'low'), (hx, 'high')]:
+            active = self._hovered == side or self._pressed == side
+            r      = self._HR_HOV if active else self._HR
+            color  = _C_RANGE_HOVER if active else _C_RANGE
+            painter.setPen(QPen(_C_HANDLE_BORDER, 2.0))
+            painter.setBrush(color)
+            painter.drawEllipse(QPointF(px, cy), r, r)
+
+        # --- value labels above handles ---
+        font = QFont()
+        font.setPointSize(8)
+        painter.setFont(font)
+        painter.setPen(_C_LABEL)
+
+        lo_txt = f"{self.low():+.{self._decimals}f}"
+        hi_txt = f"{self.high():+.{self._decimals}f}"
+        lbl_w  = 44
+
+        painter.drawText(
+            QRectF(lx - lbl_w / 2, 0, lbl_w, self._LABEL_H),
+            _ALIGN_LABEL,
+            lo_txt,
+        )
+        painter.drawText(
+            QRectF(hx - lbl_w / 2, 0, lbl_w, self._LABEL_H),
+            _ALIGN_LABEL,
+            hi_txt,
+        )
+
+        painter.end()
+
+    # -------------------------------------------------------- mouse interaction
+
+    def mousePressEvent(self, event):
+        if event.button() != _LEFT_BTN:
+            return
+        x  = _event_x(event)
+        lx = self._val_to_x(self._low)
+        hx = self._val_to_x(self._high)
+        dl = abs(x - lx)
+        dh = abs(x - hx)
+        hit = self._HR_HOV + 4
+        if dh <= hit and dh <= dl:
+            self._pressed = 'high'
+        elif dl <= hit:
+            self._pressed = 'low'
+        # else: click outside any handle — ignore
+
+    def mouseMoveEvent(self, event):
+        if self._pressed is not None:
+            self._move_to(_event_x(event))
+        else:
+            self._update_hover(_event_x(event))
+
+    def mouseReleaseEvent(self, event):
+        self._pressed = None
+        self._update_hover(_event_x(event))
+
+    def leaveEvent(self, _event):
+        if self._hovered is not None:
+            self._hovered = None
+            self.setCursor(_POINTING)
+            self.update()
+
+    def _move_to(self, x: float):
+        val = self._clamped(self._x_to_val(x))
+        if self._pressed == 'low':
+            new = min(val, self._high)
+            if new != self._low:
+                self._low = new
+                self.update()
+                self.low_changed.emit(self.low())
+        else:
+            new = max(val, self._low)
+            if new != self._high:
+                self._high = new
+                self.update()
+                self.high_changed.emit(self.high())

--- a/view/sysi.py
+++ b/view/sysi.py
@@ -45,11 +45,21 @@ from .radar import (
     _prepare_field,
     _section_panel,
 )
+from .range_slider import RangeSlider
 from .styles import STYLE_BTN_PRIMARY, STYLE_BTN_SECONDARY, STYLE_CHECKBOX
 
 
 def _tr(text):
     return QCoreApplication.translate("RAVI", text)
+
+
+def _value_lbl(text):
+    lbl = QLabel(text)
+    lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    lbl.setStyleSheet(
+        "color: #616161; font-size: 10px; background: transparent; border: none;"
+    )
+    return lbl
 
 
 _MONTHS = [
@@ -164,14 +174,13 @@ def _build_intro_tab(_dialog, parent):
     outer.addWidget(scroll, 1)
 
 
-def _threshold_row(label_text, min_widget, min_lbl, max_widget, max_lbl):
-    """A labeled Min/Max double-slider row used for the NDVI/NBR2 thresholds."""
+def _threshold_row(label_text, range_slider):
+    """A labeled range-slider row for NDVI/NBR2 thresholds."""
     box = QWidget()
     box.setStyleSheet("background: transparent;")
-    grid = QGridLayout(box)
-    grid.setContentsMargins(0, 0, 0, 0)
-    grid.setHorizontalSpacing(8)
-    grid.setVerticalSpacing(2)
+    row = QHBoxLayout(box)
+    row.setContentsMargins(0, 0, 0, 0)
+    row.setSpacing(8)
 
     name = QLabel(label_text)
     name.setMinimumWidth(54)
@@ -179,24 +188,9 @@ def _threshold_row(label_text, min_widget, min_lbl, max_widget, max_lbl):
         "color: #616161; font-size: 12px; font-weight: bold;"
         " background: transparent; border: none;"
     )
-    grid.addWidget(name, 0, 0, 2, 1)
-
-    grid.addWidget(min_lbl, 0, 1, Qt.AlignmentFlag.AlignHCenter)
-    grid.addWidget(max_lbl, 0, 2, Qt.AlignmentFlag.AlignHCenter)
-    grid.addWidget(min_widget, 1, 1)
-    grid.addWidget(max_widget, 1, 2)
-    grid.setColumnStretch(1, 1)
-    grid.setColumnStretch(2, 1)
+    row.addWidget(name)
+    row.addWidget(range_slider, 1)
     return box
-
-
-def _value_lbl(text):
-    lbl = QLabel(text)
-    lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    lbl.setStyleSheet(
-        "color: #616161; font-size: 10px; background: transparent; border: none;"
-    )
-    return lbl
 
 
 def _build_inputs_tab(dialog, parent):
@@ -321,42 +315,11 @@ def _build_inputs_tab(dialog, parent):
     thr_lay.setSpacing(10)
     thr_lay.addWidget(_field_label(_tr("BARE-SOIL THRESHOLDS")))
 
-    # NDVI: inf slider shows a negative value (value/100 negated), sup positive.
-    dialog.sysi_ndvi_inf_slider = QSlider(Qt.Orientation.Horizontal)
-    dialog.sysi_ndvi_inf_slider.setMinimum(0)
-    dialog.sysi_ndvi_inf_slider.setMaximum(100)
-    dialog.sysi_ndvi_inf_slider.setValue(25)
-    dialog.sysi_ndvi_inf_slider.setStyleSheet(_SLIDER_STYLE)
-    dialog.sysi_ndvi_sup_slider = QSlider(Qt.Orientation.Horizontal)
-    dialog.sysi_ndvi_sup_slider.setMinimum(0)
-    dialog.sysi_ndvi_sup_slider.setMaximum(100)
-    dialog.sysi_ndvi_sup_slider.setValue(25)
-    dialog.sysi_ndvi_sup_slider.setStyleSheet(_SLIDER_STYLE)
-    dialog.sysi_ndvi_inf_value = _value_lbl("-0.25")
-    dialog.sysi_ndvi_sup_value = _value_lbl("0.25")
-    thr_lay.addWidget(_threshold_row(
-        _tr("NDVI"),
-        dialog.sysi_ndvi_inf_slider, dialog.sysi_ndvi_inf_value,
-        dialog.sysi_ndvi_sup_slider, dialog.sysi_ndvi_sup_value,
-    ))
+    dialog.sysi_ndvi_range_slider = RangeSlider(-1.0, 1.0, -0.25, 0.25)
+    thr_lay.addWidget(_threshold_row(_tr("NDVI"), dialog.sysi_ndvi_range_slider))
 
-    dialog.sysi_nbr_inf_slider = QSlider(Qt.Orientation.Horizontal)
-    dialog.sysi_nbr_inf_slider.setMinimum(0)
-    dialog.sysi_nbr_inf_slider.setMaximum(100)
-    dialog.sysi_nbr_inf_slider.setValue(30)
-    dialog.sysi_nbr_inf_slider.setStyleSheet(_SLIDER_STYLE)
-    dialog.sysi_nbr_sup_slider = QSlider(Qt.Orientation.Horizontal)
-    dialog.sysi_nbr_sup_slider.setMinimum(0)
-    dialog.sysi_nbr_sup_slider.setMaximum(100)
-    dialog.sysi_nbr_sup_slider.setValue(10)
-    dialog.sysi_nbr_sup_slider.setStyleSheet(_SLIDER_STYLE)
-    dialog.sysi_nbr_inf_value = _value_lbl("-0.30")
-    dialog.sysi_nbr_sup_value = _value_lbl("0.10")
-    thr_lay.addWidget(_threshold_row(
-        _tr("NBR2"),
-        dialog.sysi_nbr_inf_slider, dialog.sysi_nbr_inf_value,
-        dialog.sysi_nbr_sup_slider, dialog.sysi_nbr_sup_value,
-    ))
+    dialog.sysi_nbr_range_slider = RangeSlider(-1.0, 1.0, -0.30, 0.10)
+    thr_lay.addWidget(_threshold_row(_tr("NBR2"), dialog.sysi_nbr_range_slider))
 
     hint = QLabel(_tr("Keep Min &lt; Max. Pixels inside both ranges are kept as bare soil."))
     hint.setTextFormat(Qt.TextFormat.RichText)
@@ -364,23 +327,6 @@ def _build_inputs_tab(dialog, parent):
         "color: #9e9e9e; font-size: 10px; background: transparent; border: none;"
     )
     thr_lay.addWidget(hint)
-
-    def _sync_ndvi_inf(v):
-        dialog.sysi_ndvi_inf_value.setText(f"{-v / 100:.2f}")
-
-    def _sync_ndvi_sup(v):
-        dialog.sysi_ndvi_sup_value.setText(f"{v / 100:.2f}")
-
-    def _sync_nbr_inf(v):
-        dialog.sysi_nbr_inf_value.setText(f"{-v / 100:.2f}")
-
-    def _sync_nbr_sup(v):
-        dialog.sysi_nbr_sup_value.setText(f"{v / 100:.2f}")
-
-    dialog.sysi_ndvi_inf_slider.valueChanged.connect(_sync_ndvi_inf)
-    dialog.sysi_ndvi_sup_slider.valueChanged.connect(_sync_ndvi_sup)
-    dialog.sysi_nbr_inf_slider.valueChanged.connect(_sync_nbr_inf)
-    dialog.sysi_nbr_sup_slider.valueChanged.connect(_sync_nbr_sup)
     lay.addWidget(thr_panel)
 
     # --- Cloud cover -----------------------------------------------------
@@ -492,8 +438,7 @@ def setup_sysi_page(dialog, page):
     Exposes on dialog:
       sysi_layer_combo, sysi_btn_draw_aoi, sysi_btn_hybrid_layer,
       sysi_date_start, sysi_date_end, sysi_month_checks,
-      sysi_ndvi_inf_slider, sysi_ndvi_sup_slider,
-      sysi_nbr_inf_slider, sysi_nbr_sup_slider,
+      sysi_ndvi_range_slider, sysi_nbr_range_slider  (RangeSlider instances),
       sysi_cloud_slider, sysi_buffer_slider,
       sysi_stack, sysi_set_tab, sysi_btn_back, sysi_btn_generate, sysi_step_lbl
     """

--- a/workers/sysi_worker.py
+++ b/workers/sysi_worker.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""
+Background worker for the SYSI page's GEE composite generation.
+
+The GEOS3 pipeline (Sentinel-2 collection build, bare-soil masking, median
+composite, and GeoTIFF download) is a slow network-bound operation that must
+run off the UI thread to keep the dialog responsive.  The AOI is extracted
+from the QGIS layer on the main thread (layers are not thread-safe) and
+passed in already as an ee.FeatureCollection.
+"""
+
+from qgis.PyQt.QtCore import QThread, pyqtSignal
+
+from ..services.sysi_service import SYSIService
+
+
+class SYSIWorker(QThread):
+    """Run the GEOS3 bare-soil composite pipeline and download the result.
+
+    Signals
+    -------
+    finished(output_path, label)
+        Emitted on success with the local GeoTIFF path and a display label.
+    failed(error_message)
+        Emitted when any exception is raised during processing or download.
+    """
+
+    finished = pyqtSignal(str, str)
+    failed = pyqtSignal(str)
+
+    def __init__(self, aoi, params):
+        """
+        Parameters
+        ----------
+        aoi : ee.FeatureCollection
+            Area of interest, possibly buffered by the controller.
+        params : dict
+            Keys expected:
+              start_date, end_date   – ``'YYYY-MM-DD'`` strings
+              cloud_threshold        – int (0–100)
+              ndvi_thres             – [min, max] floats
+              nbr_thres              – [min, max] floats
+              selected_months        – list[int] (1–12)
+              output_folder          – str path (or None for system temp)
+              label                  – str display name for the QGIS layer
+        """
+        super().__init__()
+        self._aoi = aoi
+        self._params = params
+
+    def run(self):
+        try:
+            p = self._params
+            composite = SYSIService.build_composite(
+                aoi=self._aoi,
+                start_date=p["start_date"],
+                end_date=p["end_date"],
+                cloud_threshold=p["cloud_threshold"],
+                ndvi_thres=p["ndvi_thres"],
+                nbr_thres=p["nbr_thres"],
+                selected_months=p["selected_months"],
+            )
+            output_path = SYSIService.download_composite(
+                composite,
+                self._aoi,
+                output_folder=p.get("output_folder"),
+            )
+            self.finished.emit(output_path, p.get("label", "SYSI"))
+        except Exception as exc:
+            self.failed.emit(str(exc))


### PR DESCRIPTION
## Summary
- Implements the backend for the existing SYSI page so it can generate a GEOS3 bare-soil composite from Sentinel-2 and load it into QGIS
- Ports the validated pipeline from \`dev/08_sysi_soil_image.ipynb\` verbatim (cloud mask → rename bands → month filter → add indexes → scale factors → GEOS3 mask → median composite)
- Adds a custom \`RangeSlider\` widget for NDVI and NBR2 min/max threshold selection
- Runs the GEE pipeline in a \`QThread\` worker so the UI never freezes
- Loads the downloaded GeoTIFF as a natural-colour RGB raster (2-98% contrast stretch) directly into QGIS

## Files
- \`services/sysi_service.py\` - GEOS3 pipeline and GeoTIFF download
- \`workers/sysi_worker.py\` - background QThread worker
- \`controllers/sysi_ctrl.py\` - UI to service wiring, AOI extraction, layer loading
- \`view/range_slider.py\` - custom two-handle range slider widget
- \`view/sysi.py\` - integrated RangeSlider for NDVI/NBR2 thresholds
- \`ravi.py\` - wired SYSICtrl signals and slots


## Issue #5 